### PR TITLE
Update client-side check whether user can contribute datasets

### DIFF
--- a/web_client/js/DatasetsView.js
+++ b/web_client/js/DatasetsView.js
@@ -43,7 +43,31 @@ girder.views.IsicDatasetsView = girder.View.extend({
 
 
 girder.models.IsicDatasetModel = girder.Model.extend({
-
+    /**
+     * Check whether user is a member of the dataset contributor group.
+     *
+     * The callback is called with a boolean argument. When true, the user is a
+     * member of the dataset contributor group.
+     *
+     */
+    userCanContribute: function (user, callback) {
+        var groups = new girder.collections.GroupCollection();
+        groups.once('g:changed', function () {
+            if (!groups.isEmpty()) {
+                var groupId = groups.first().id;
+                var userGroups = girder.currentUser.get('groups');
+                var datasetContributor = _.contains(userGroups, groupId);
+                callback(datasetContributor);
+            } else {
+                callback(false);
+            }
+        }, this).once('g:error', function () {
+            callback(false);
+        }, this).fetch({
+            text: 'Dataset Contributors',
+            exact: true
+        });
+    }
 });
 
 girder.collections.IsicDatasetCollection = girder.Collection.extend({

--- a/web_external/js/views/body/FrontPageView.js
+++ b/web_external/js/views/body/FrontPageView.js
@@ -11,6 +11,16 @@ isic.views.FrontPageView = girder.views.FrontPageView.extend({
 
     initialize: function () {
         girder.cancelRestRequests('fetch');
+
+        this.datasetContributor = false;
+
+        // Check whether user has permission to contribute datasets
+        var datasetModel = new girder.models.IsicDatasetModel();
+        datasetModel.userCanContribute(girder.currentUser, _.bind(function (datasetContributor) {
+            this.datasetContributor = datasetContributor;
+            this.render();
+        }, this));
+
         this.render();
     },
 
@@ -20,7 +30,7 @@ isic.views.FrontPageView = girder.views.FrontPageView.extend({
         this.$el.html(isic.templates.frontPage({
             apiRoot: girder.apiRoot,
             staticRoot: girder.staticRoot,
-            currentUser: girder.currentUser,
+            datasetContributor: this.datasetContributor,
             versionInfo: girder.versionInfo
         }));
 

--- a/web_external/js/views/body/UploadDatasetView.js
+++ b/web_external/js/views/body/UploadDatasetView.js
@@ -246,9 +246,13 @@ isic.views.UploadDatasetView = isic.View.extend({
 });
 
 isic.router.route('uploadDataset', 'uploadDataset', function (id) {
-    if (girder.currentUser) {
-        girder.events.trigger('g:navigateTo', isic.views.UploadDatasetView);
-    } else {
-        isic.router.navigate('', {trigger: true});
-    }
+    // Route to index if user doesn't have permission to contribute datasets
+    var datasetModel = new girder.models.IsicDatasetModel();
+    datasetModel.userCanContribute(girder.currentUser, _.bind(function (datasetContributor) {
+        if (datasetContributor) {
+            girder.events.trigger('g:navigateTo', isic.views.UploadDatasetView);
+        } else {
+            isic.router.navigate('', {trigger: true});
+        }
+    }, this));
 });

--- a/web_external/templates/body/frontPage.jade
+++ b/web_external/templates/body/frontPage.jade
@@ -2,6 +2,6 @@
   .isic-frontpage-container
     .isic-example-button.isic-frontpage-button
       | Example view
-    if currentUser
+    if datasetContributor
       .isic-upload-dataset-button.isic-frontpage-button
         | Upload dataset


### PR DESCRIPTION
The client now checks whether the current user is a member of the dataset
contributors group. This determines whether the 'Upload dataset' link is shown
on the front page and whether the upload dataset view route can be accessed.