### PR TITLE
Remove hardcoded relative path from ESLint config

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -1,6 +1,6 @@
 add_eslint_test(
   isic_archive "${PROJECT_SOURCE_DIR}/plugins/isic_archive/web_external/js"
-  ESLINT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/plugins/isic_archive/web_external/js/.eslintrc"
+  ESLINT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/plugins/isic_archive/web_external/js/.eslintrc.js"
   ESLINT_IGNORE_FILE "${PROJECT_SOURCE_DIR}/plugins/isic_archive/web_external/js/.eslintignore"
 )
 

--- a/web_external/js/.eslintrc
+++ b/web_external/js/.eslintrc
@@ -1,6 +1,0 @@
-{
-    "extends": "../../../../.eslintrc",
-    "globals": {
-        "isic": true
-    }
-}

--- a/web_external/js/.eslintrc.js
+++ b/web_external/js/.eslintrc.js
@@ -1,0 +1,8 @@
+var path = require('path');
+
+module.exports = {
+    "extends": path.join(process.cwd(), ".eslintrc"),
+    "globals": {
+        "isic": true
+    }
+};


### PR DESCRIPTION
This commit allows running the ESLint JavaScript static analysis tests no matter
where the repository is located relative to the Girder repository. For example,
the tests now run when the plugin is deployed using Vagrant.