### PR TITLE
WIP: Add study page

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,6 +105,8 @@ module.exports = function (grunt) {
                 jsDir + '/isic_archive-version.js',
                 jsDir + '/view.js',
                 jsDir + '/app.js',
+                jsDir + '/models/**/*.js',
+                jsDir + '/collections/**/*.js',
                 jsDir + '/views/**/*.js'
             ];
             files[staticDir + '/main.min.js'] = [

--- a/web_client/js/DatasetsView.js
+++ b/web_client/js/DatasetsView.js
@@ -88,7 +88,7 @@ girder.views.IsicDatasetWidget = girder.View.extend({
             parentView: this
         }).render();
 
-        this.imageCollection = new girder.collections.IsicImageCollection();
+        this.imageCollection = new isic.collections.ImageCollection();
         this.imageCollection.on('g:changed', function () {
             this.render();
         }, this).fetch({
@@ -105,16 +105,3 @@ girder.views.IsicDatasetWidget = girder.View.extend({
         return this;
     }
 });
-
-
-girder.models.IsicImageModel = girder.Model.extend({
-
-});
-
-girder.collections.IsicImageCollection = girder.Collection.extend({
-    resourceName: 'image',
-    model: girder.models.IsicImageModel
-    // TODO: make pageLimit unlimited, or add pagination to the view
-});
-
-

--- a/web_external/js/collections/FeaturesetCollection.js
+++ b/web_external/js/collections/FeaturesetCollection.js
@@ -1,0 +1,4 @@
+isic.collections.FeaturesetCollection = girder.Collection.extend({
+    resourceName: 'featureset',
+    model: isic.models.FeaturesetModel
+});

--- a/web_external/js/collections/ImageCollection.js
+++ b/web_external/js/collections/ImageCollection.js
@@ -1,0 +1,4 @@
+isic.collections.ImageCollection = girder.Collection.extend({
+    resourceName: 'image',
+    model: isic.models.ImageModel
+});

--- a/web_external/js/collections/SegmentationCollection.js
+++ b/web_external/js/collections/SegmentationCollection.js
@@ -1,0 +1,4 @@
+isic.collections.SegmentationCollection = girder.Collection.extend({
+    resourceName: 'segmentation',
+    model: isic.models.SegmentationModel
+});

--- a/web_external/js/collections/StudyCollection.js
+++ b/web_external/js/collections/StudyCollection.js
@@ -1,0 +1,4 @@
+isic.collections.StudyCollection = girder.Collection.extend({
+    resourceName: 'study',
+    model: isic.models.StudyModel
+});

--- a/web_external/js/models/FeaturesetModel.js
+++ b/web_external/js/models/FeaturesetModel.js
@@ -1,0 +1,3 @@
+isic.models.FeaturesetModel = girder.Model.extend({
+    resourceName: 'featureset'
+});

--- a/web_external/js/models/ImageModel.js
+++ b/web_external/js/models/ImageModel.js
@@ -1,0 +1,3 @@
+isic.models.ImageModel = girder.Model.extend({
+    resourceName: 'image'
+});

--- a/web_external/js/models/SegmentationModel.js
+++ b/web_external/js/models/SegmentationModel.js
@@ -1,0 +1,3 @@
+isic.models.SegmentationModel = girder.Model.extend({
+    resourceName: 'segmentation'
+});

--- a/web_external/js/models/StudyModel.js
+++ b/web_external/js/models/StudyModel.js
@@ -1,0 +1,3 @@
+isic.models.StudyModel = girder.Model.extend({
+    resourceName: 'study'
+});

--- a/web_external/js/views/body/FrontPageView.js
+++ b/web_external/js/views/body/FrontPageView.js
@@ -4,6 +4,10 @@ isic.views.FrontPageView = girder.views.FrontPageView.extend({
             isic.router.navigate('example', {trigger: true});
         },
 
+        'click .isic-studies-button': function () {
+            isic.router.navigate('studies', {trigger: true});
+        },
+
         'click .isic-upload-dataset-button': function () {
             isic.router.navigate('uploadDataset', {trigger: true});
         }

--- a/web_external/js/views/body/StudiesView.js
+++ b/web_external/js/views/body/StudiesView.js
@@ -1,0 +1,60 @@
+isic.views.StudiesView = isic.View.extend({
+    events: {
+        'show.bs.collapse .isic-study-panel-collapse': function (event) {
+            var target = $(event.target);
+            target.parent().find('.icon-right-open').removeClass('icon-right-open').addClass('icon-down-open');
+
+            var viewIndex = window.parseInt(target.attr('data-study-index'), 10);
+            var viewContainer = target.find('.isic-study-panel-body');
+            this.renderStudy(viewIndex, viewContainer);
+        },
+        'hide.bs.collapse .isic-study-panel-collapse': function (event) {
+            $(event.target).parent().find('.icon-down-open').removeClass('icon-down-open').addClass('icon-right-open');
+        }
+    },
+
+    initialize: function (settings) {
+        girder.cancelRestRequests('fetch');
+
+        // TODO: filter by state?
+        this.studies = new isic.collections.StudyCollection();
+        this.studies.once('g:changed', function () {
+            this.render();
+        }, this).fetch();
+
+        this.render();
+    },
+
+    render: function () {
+        this.$el.html(isic.templates.studiesPage({
+            studies: this.studies
+        }));
+
+        return this;
+    },
+
+    renderStudy: function (index, container) {
+        if (container.children().length === 0) {
+            // Display loading indicator
+            new girder.views.LoadingAnimation({
+                el: container,
+                parentView: this
+            }).render();
+
+            // Fetch study details
+            var study = new isic.models.StudyModel({
+                _id: this.studies.at(index).id
+            }).once('g:fetched', function () {
+                new isic.views.StudyView({ // eslint-disable-line no-new
+                    el: container,
+                    study: study,
+                    parentView: this
+                });
+            }, this).fetch();
+        }
+    }
+});
+
+isic.router.route('studies', 'studies', function (id) {
+    girder.events.trigger('g:navigateTo', isic.views.StudiesView);
+});

--- a/web_external/js/views/body/StudyView.js
+++ b/web_external/js/views/body/StudyView.js
@@ -1,0 +1,62 @@
+isic.views.StudyView = isic.View.extend({
+    initialize: function (settings) {
+        girder.cancelRestRequests('fetch');
+
+        this.study = settings.study;
+
+        var promises = [];
+
+        // TODO: Add way to detect collection fetch error. On error, set
+        // collection to null and reject promise.
+
+        var usersDeferred = $.Deferred();
+        promises.push(usersDeferred.promise());
+        this.users = new girder.collections.UserCollection();
+        this.users.altUrl = 'study/' + this.study.id + '/user';
+        this.users.once('g:changed', function () {
+            usersDeferred.resolve();
+        }, this).fetch();
+
+        var featuresetDeferred = $.Deferred();
+        promises.push(featuresetDeferred.promise());
+        this.featureset = new isic.models.FeaturesetModel({
+            _id: this.study.get('featuresetId')
+        }).once('g:fetched', function () {
+            featuresetDeferred.resolve();
+        }, this).fetch();
+
+        var imagesDeferred = $.Deferred();
+        promises.push(imagesDeferred.promise());
+        this.images = new isic.collections.ImageCollection();
+        this.images.altUrl = 'study/' + this.study.id + '/image';
+        this.images.once('g:changed', function () {
+            imagesDeferred.resolve();
+        }, this).fetch();
+
+        var segmentationsDeferred = $.Deferred();
+        promises.push(segmentationsDeferred.promise());
+        this.segmentations = new isic.collections.SegmentationCollection();
+        this.segmentations.altUrl = 'study/' + this.study.id + '/segmentation';
+        this.segmentations.once('g:changed', function () {
+            segmentationsDeferred.resolve();
+        }, this).fetch();
+
+        $.when.apply($, promises).done(_.bind(function () {
+            this.render();
+        }, this)).fail(_.bind(function () {
+            this.render();
+        }, this));
+    },
+
+    render: function () {
+        this.$el.html(isic.templates.studyPage({
+            study: this.study,
+            users: this.users,
+            featureset: this.featureset,
+            images: this.images,
+            segmentations: this.segmentations
+        }));
+
+        return this;
+    }
+});

--- a/web_external/stylesheets/body/studiesPage.styl
+++ b/web_external/stylesheets/body/studiesPage.styl
@@ -1,0 +1,5 @@
+.isic-study-panel-heading
+  font-size 20px
+  a
+  i
+    color grey

--- a/web_external/stylesheets/body/studyPage.styl
+++ b/web_external/stylesheets/body/studyPage.styl
@@ -1,0 +1,10 @@
+content-margin = 20px
+.isic-study-users-content
+.isic-study-featureset-content
+.isic-study-images-content
+.isic-study-segmentations-content
+  margin-left content-margin
+
+// For now, hide segmentations
+.isic-study-segmentations-container
+  display none

--- a/web_external/templates/body/frontPage.jade
+++ b/web_external/templates/body/frontPage.jade
@@ -2,6 +2,8 @@
   .isic-frontpage-container
     .isic-example-button.isic-frontpage-button
       | Example view
+    .isic-studies-button.isic-frontpage-button
+      | Annotation studies
     if datasetContributor
       .isic-upload-dataset-button.isic-frontpage-button
         | Upload dataset

--- a/web_external/templates/body/studiesPage.jade
+++ b/web_external/templates/body/studiesPage.jade
@@ -1,0 +1,22 @@
+.isic-studies-header
+  .isic-studies-title
+    h2
+      | Annotation Studies
+    h4
+      | #{studies.length} studies
+
+.isic-studies-container
+  each study, index in studies.models
+    .isic-study-panel-group.panel-group
+      .isic-study-panel.panel.panel-default
+        .isic-study-panel-heading.panel-heading
+          a(data-toggle="collapse" data-target="#{'#panel-' + study.cid}").collapsed
+            | #{study.get('name')}
+            span.isic-study-panel-heading-indicator.pull-right
+              i.icon-right-open
+        .isic-study-panel-collapse.panel-collapse.collapse(
+          id="#{'panel-' + study.cid}"
+          data-study-index="#{index}"
+          )
+          .isic-study-panel-body.panel-body
+

--- a/web_external/templates/body/studyPage.jade
+++ b/web_external/templates/body/studyPage.jade
@@ -1,0 +1,48 @@
+.isic-study-users-container
+  h4 Users
+  .isic-study-users-content
+    if users
+      if users.length
+        - var logins = users.pluck('login')
+        = logins.join(', ')
+      else
+        | (no users)
+    else
+      i.icon-error (error)
+
+.isic-study-featureset-container
+  h4 Featureset
+  .isic-study-featureset-content
+    if featureset
+      | #{featureset.get('name')}, version #{featureset.get('version')}
+    else
+      i.icon-error (error)
+
+.isic-study-images-container
+  h4 Images
+    if images
+      |  (#{images.length})
+  .isic-study-images-content
+    if images
+      if images.length
+        - var imageNames = images.pluck('name')
+        = imageNames.join(', ')
+      else
+        | (no images)
+    else
+      i.icon-error (error)
+
+.isic-study-segmentations-container
+  h4 Segmentations
+    if segmentations
+      |  (#{segmentations.length})
+  .isic-study-segmentations-content
+    if segmentations
+      if segmentations.length
+        - var segmentationsIds = segmentations.pluck('_id')
+        = segmentationsIds.join(', ')
+      else
+        | (no segmentations)
+    else
+      i.icon-error (error)
+


### PR DESCRIPTION
The study page lists annotation studies. Initially, each study's name is shown
in the header of a collapsed panel. When the user clicks a study's name, the
panel expands to show the study details. Currently, only the information
directly available from the /study/id/* endpoints is fetched/shown.