### PR TITLE
WIP: Add WorkingGroupMembers Page

### DIFF
--- a/web_external/templates/body/workinggroupmembersPage.jade
+++ b/web_external/templates/body/workinggroupmembersPage.jade
@@ -1,0 +1,182 @@
+.isic-frontpage
+  .isic-frontpage-body
+    h3
+      strong Technique Working Group:
+    table(border='0', align='left')
+      tbody
+        tr
+          td(align='left', valign='top') H. Peter Soyer, MD (Co-Leader)
+          td(align='left', valign='top')
+            | Dermatology Research Centre, The University of Queensland School of Medicine Translational Research Institute
+          td(align='left', valign='top') Brisbane, Australia
+        tr
+          td(align='left', valign='top') Clara Curiel, MD (Co-Leader)
+          td(align='left', valign='top') University of Arizona Cancer Center and Section of Dermatology
+          td(align='left', valign='top') Tucson, AZ
+        tr
+          td(align='left', valign='top') Dennis DaSilva, BS
+          td(align='left', valign='top') Canfield Scientific Inc.
+          td(align='left', valign='top') Fairfield, NJ
+        tr
+          td(align='left', valign='top') Whitney A. High, MD, JD, MEng
+          td(align='left', valign='top') University of Colorado Denver
+          td(align='left', valign='top') Aurora, CO
+        tr
+          td(align='left', valign='top') Lynne H. Morrison, MD
+          td(align='left', valign='top') Oregon Health and Science University
+          td(align='left', valign='top') Portland, OR
+        tr
+          td(align='left', valign='top') Jeb Zirato, BS
+          td(align='left', valign='top') University of Arizona Cancer Center
+          td(align='left', valign='top') Tucson, AZ
+    p  
+    h3
+      br
+      br
+      br
+      br
+      br
+    h3
+      strong Terminology Working Group
+      | :
+    table
+      tbody
+        tr
+          td(align='left', valign='top') Harald Kittler, MD (Leader)
+          td(align='left', valign='top') Department of Dematology, Medical University of Vienna
+          td(align='left', valign='top') Vienna, Austria
+        tr
+          td(align='left', valign='top') Giuseppe Argenziano, MD
+          td(align='left', valign='top') Arcispedale S. Maria Nuova
+          td(align='left', valign='top') Reggio Emilia, Italy
+        tr
+          td(align='left', valign='top') Ralph P. Braun, MD
+          td(align='left', valign='top') University Hospital of Zurich
+          td(align='left', valign='top') Zurich, Switzerland
+        tr
+          td(align='left', valign='top') Holger Haenssle, MD
+          td(align='left', valign='top') University Medical Centre
+          td(align='left', valign='top') Goettingen, Germany
+        tr
+          td(align='left', valign='top') Ashfaq A. Marghoob, MD
+          td(align='left', valign='top') Memorial Sloan Kettering Cancer Center
+          td(align='left', valign='top') New York, NY
+        tr
+          td(align='left', valign='top') Scott W. Menzies, MD
+          td(align='left', valign='top') University of Sydney at the Sydney Cancer Centre
+          td(align='left', valign='top') Sydney, Australia
+        tr
+          td(align='left', valign='top') Susanna Puig, MD
+          td(align='left', valign='top') Hospital Clinic of Barcelona
+          td(align='left', valign='top') Barcelona, Spain
+        tr
+          td(align='left', valign='top') Alon Scope, MD
+          td(align='left', valign='top') Sheba Medical Center and Sackler Faculty of Medicine
+          td(align='left', valign='top') Tel Aviv, Israel
+        tr
+          td(align='left', valign='top') Wilhelm Stolz, MD
+          td(align='left', valign='top') Munich Municipal Hospital Group
+          td(align='left', valign='top') Munich, Germany
+        tr
+          td(align='left', valign='top') Luc Thomas, MD, PhD
+          td(align='left', valign='top') University Claude Bernard Lyon and Cancer Research Center of Lyon
+          td(align='left', valign='top') Lyon, France
+        tr
+          td(align='left', valign='top') Philipp Tschandl, MD
+          td(align='left', valign='top') Department of Dermatology, Medical University of Vienna
+          td(align='left', valign='top') Vienna, Austria
+        tr
+          td(align='left', valign='top') Iris Zalaudek, MD
+          td(align='left', valign='top') Medical University of Graz
+          td(align='left', valign='top') Graz, Austria
+    p  
+    h3
+      strong Technology Working Group
+      | :
+    table(border='0', align='left')
+      tbody
+        tr
+          td(align='left', valign='top') Josep Malvehy, MD (Leader)
+          td(align='left', valign='top') Hospital Clinic of Barcelona. IDIBAPS. CIBER de enfermedades raras.
+          td(align='left', valign='top') Barcelona, Spain
+        tr
+          td(align='left', valign='top') Mani Abedini, PhD
+          td(align='left', valign='top') IBM Research Australia
+          td(align='left', valign='top') Melbourne, Australia
+        tr
+          td(align='left', valign='top') Liam Caffery PhD
+          td(align='left', valign='top') University of Queensland
+          td(align='left', valign='top') Brisbane, Australia
+        tr
+          td(align='left', valign='top') Doug Canfield, BS
+          td(align='left', valign='top') Canfield Scientific Inc.
+          td(align='left', valign='top') Fairfield, NJ
+        tr
+          td(align='left', valign='top') Qiang Chen, PhD
+          td(align='left', valign='top') IBM Research Australia
+          td(align='left', valign='top') Melbourne, Australia
+        tr
+          td(align='left', valign='top') Noel C.F. Codella, PhD
+          td(align='left', valign='top') IBM T.J. Watson Research Center
+          td(align='left', valign='top') Yorktown Heights, NY
+        tr
+          td(align='left', valign='top') Rafael Garcia, PhD
+          td(align='left', valign='top') University of Girona
+          td(align='left', valign='top') Girona, Spain
+        tr
+          td(align='left', valign='top') Rahil Garnavi, PhD
+          td(align='left', valign='top') IBM Research Australia
+          td(align='left', valign='top') Melbourne, Australia
+        tr
+          td(align='left', valign='top') Constantino Grana, PhD
+          td(align='left', valign='top') University of Modena and Reggio Emilia
+          td(align='left', valign='top') Modena, Italy
+        tr
+          td(align='left', valign='top') Peter Klar
+          td(align='left', valign='top') Visiomed AG
+          td(align='left', valign='top') Bielefeld, Germany
+        tr
+          td(align='left', valign='top') Andreas Mayer
+          td(align='left', valign='top') FotoFinder Systems, Inc.
+          td(align='left', valign='top') Bad Birnbach, Germany
+        tr
+          td(align='left', valign='top') Ferdinand Mayer
+          td(align='left', valign='top') FotoFinder Systems, Inc.
+          td(align='left', valign='top') Columbia, MD
+        tr
+          td(align='left', valign='top') Scott W. Menzies, MD
+          td(align='left', valign='top') University of Sydney at the Sydney Cancer Centre
+          td(align='left', valign='top') Sydney, Australia
+        tr
+          td(align='left', valign='top') Matthew A. Molenda, MD
+          td(align='left', valign='top') ProMedica
+          td(align='left', valign='top') Toledo, OH
+        tr
+          td(align='left', valign='top') Nizar Mullani, BSc
+          td(align='left', valign='top') 3GEN LLC and TransLite LLC
+          td(align='left', valign='top') USA
+        tr
+          td(align='left', valign='top') Giovanni Pellacani, MD
+          td(align='left', valign='top') University of Modena and Reggio Emilia
+          td(align='left', valign='top') Modena, Italy
+        tr
+          td(align='left', valign='top') Susanna Puig, MD
+          td(align='left', valign='top') Hospital Clinic of Barcelona
+          td(align='left', valign='top') Barcelona, Spain
+        tr
+          td(align='left', valign='top') Josep Quintana, PhD
+          td(align='left', valign='top') University of Girona
+          td(align='left', valign='top') Girona, Spain
+        tr
+          td(align='left', valign='top') Victor Skladnev, BSc, MEng
+          td(align='left', valign='top') AIMEDICS Pty Ltd
+          td(align='left', valign='top') Sydney, Australia
+        tr
+          td(align='left', valign='top') William V. Stoecker, MD
+          td(align='left', valign='top') University of Missouri Health System
+          td(align='left', valign='top') Columbia, MO
+        tr
+          td(align='left', valign='top') Xingzhi Sun, PhD
+          td(align='left', valign='top') IBM Research Australia
+          td(align='left', valign='top') Melbourne, Australia
+


### PR DESCRIPTION
A page that lists the different working groups of ISIC and the members
who belong to each group. Would benefit from being a dropdown option from About.
@brianhelba I quickly copied the HTML. The original page is here: [http://isdis.net/isic-project/working-group-members/](http://isdis.net/isic-project/working-group-members/). The existing isic stylesheets are fine for this

