### PR TITLE
Refactor image creation and superpixel handling

### DIFF
--- a/ansible/roles/isic/vars/main.yml
+++ b/ansible/roles/isic/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 
-girder_version: "e9c745648f573b40a0987e3b352613e28c28e980"
+girder_version: "f8eb0278a42f79da40d438587e1694ae52ca62fd"
 python_dist: "conda"
 python_dist_path: "{{ ansible_user_dir }}/env"
 large_image_version: "371ed81d93e3ad198f5d56902f9a0797f16c84b2"

--- a/custom/phase1.html
+++ b/custom/phase1.html
@@ -184,7 +184,7 @@
                     <div ng-if="isSubmitting"
                          ng-controller="SubmitProgressController">
                         <div class="alert alert-success">
-                            <span>Uploading and creating superpixels...</span>
+                            <span>Submitting...</span>
                             <uib-progressbar
                                     max="max"
                                     value="value">

--- a/custom/static/js/UDASegment.js
+++ b/custom/static/js/UDASegment.js
@@ -10,7 +10,7 @@ window.UDASegment = function (imageId, segmentationId, options) {
 
     function onSourceSuccessLoad(_image, options) {
 
-        tile_image.src = '/api/v1/segmentation/' + segmentationId + '/superpixels';
+        tile_image.src = '/api/v1/image/' + imageId + '/superpixels';
         tile_image.crossOrigin = null;
         tile_image.onerror = function () { onErrorImageLoad(_image); };
         tile_image.onload = function (){ onSuccessImageLoad(_image, tile_image, options); };

--- a/custom/static/js/dermapp-phase1.js
+++ b/custom/static/js/dermapp-phase1.js
@@ -109,8 +109,8 @@ derm_app.controller('SubmitProgressController', [
     '$scope', '$interval',
     function ($scope, $interval) {
         $scope.value = 0.0;
-        var interval = 0.5;
-        $scope.max = 10.0;
+        var interval = 0.2;
+        $scope.max = 2.0;
 
         function increment () {
             $scope.value += interval;

--- a/server/api/segmentation.py
+++ b/server/api/segmentation.py
@@ -37,8 +37,6 @@ class SegmentationResource(Resource):
         self.route('GET', (':id',), self.getSegmentation)
         self.route('GET', (':id', 'thumbnail'), self.thumbnail)
 
-        self.route('GET', (':id', 'superpixels'), self.getSuperpixels)
-
     @describeRoute(
         Description('List the segmentations for an image.')
         .param('imageId', 'The ID of the image.', paramType='query')
@@ -161,17 +159,3 @@ class SegmentationResource(Resource):
         cherrypy.response.headers['Content-Length'] = len(thumbnailImageData)
 
         return thumbnailImageData
-
-    @describeRoute(
-        Description('Get the superpixels for this segmentation, as a'
-                    ' PNG-encoded label map.')
-        .param('id', 'The ID of the segmentation.', paramType='path')
-        .errorResponse('ID was invalid.')
-    )
-    @access.cookie
-    @access.public
-    @loadmodel(model='segmentation', plugin='isic_archive')
-    def getSuperpixels(self, segmentation, params):
-        Segmentation = self.model('segmentation', 'isic_archive')
-        superpixelsFile = Segmentation.superpixelsFile(segmentation)
-        return self.model('file').download(superpixelsFile, headers=True)

--- a/server/models/dataset.py
+++ b/server/models/dataset.py
@@ -24,7 +24,7 @@ from girder.constants import AccessType
 from girder.models.folder import Folder as FolderModel
 from girder.models.model_base import ValidationException
 
-from ..upload import handleCsv, handleImage, handleZip
+from ..upload import handleCsv, handleZip
 
 ZIP_FORMATS = [
     'multipart/x-zip',
@@ -172,7 +172,8 @@ class Dataset(FolderModel):
         datasetFolder = self.setMetadata(datasetFolder, {
             'signature': signature,
             'anonymous': anonymous,
-            'attribution': attribution
+            'attribution': attribution,
+            'license': license
         })
 
         # Process zip files
@@ -181,10 +182,6 @@ class Dataset(FolderModel):
             for zipFile in zipFiles:
                 # TODO: gracefully clean up after exceptions in handleZip
                 handleZip(datasetFolder, user, zipFile)
-
-        # Process extracted images
-        for item in self.model('folder').childItems(datasetFolder):
-            handleImage(item, user, license)
 
         # Process metadata in CSV files
         for item in csvFileItems:

--- a/server/provision_utility.py
+++ b/server/provision_utility.py
@@ -171,7 +171,7 @@ def initialSetup(info):
         collection_description='Images to QC',
         public=False,
         group_name='Phase 0',
-        group_description='Users responsible for uploading raw images & metadata, and doing initial QC'
+        group_description='Users responsible for doing initial QC'
     )
 
     # Create empty "dataset contributors" group
@@ -221,19 +221,6 @@ def initialSetup(info):
         public=True,
         group_name='Study Administrators',
         group_description='Annotation study creators and administrators'
-    )
-
-    dropzip_folder = _ISICCollection.createFolder(
-        name='dropzip',
-        description='Upload zipped folders of images here',
-        parent=ISIC.Phase0.collection,
-        parent_type='collection'
-    )
-    ModelImporter.model('folder').setGroupAccess(
-        doc=dropzip_folder,
-        group=ISIC.Phase0.group,
-        level=AccessType.WRITE,
-        save=True
     )
 
     for featureset_file_name in [

--- a/web_external/templates/body/uploadDataset.jade
+++ b/web_external/templates/body/uploadDataset.jade
@@ -25,9 +25,9 @@
           | Upload a ZIP file of images.
         .isic-upload-description-csv
           | Upload a CSV file of image metadata. The <i>filename</i> column
-          | should contain an image filename. All other columns are considered
-          | to be clinical metadata. Column names may not contain the period
-          | (.) character.
+          | should contain an image filename (including file extension). All
+          | other columns are considered to be clinical metadata; these other
+          | column names may not contain the period (.) character.
       .isic-upload-container
         .isic-upload-widget-container
         .isic-upload-reset-container


### PR DESCRIPTION
* Refactor superpixel and Image model code 
  * Move segmentation creation into Segmentation model
  * Move superpixel creation into Image model
  * Move superpixel access into Image model / API
  * Move large_image (multiresolution TIFF) creation into Image model
  * Store full filename in Image.meta.originalFilename
  * Fix a bug where CSV metadata was not matched
* Provision a more recent version of Girder with prefixSearch bugfix
* Do not automatically create the "dropzip" folder