### PR TITLE
Fix disappearing paging buttons

### DIFF
--- a/web_external/stylesheets/body/imagesPage.styl
+++ b/web_external/stylesheets/body/imagesPage.styl
@@ -56,6 +56,7 @@ $dataAxisColor = #333333
         img
             width 1em
             height 1em
+            opacity 0.7
 
         &.selected
             img
@@ -67,8 +68,7 @@ $dataAxisColor = #333333
             background linear-gradient(to bottom, #fff 60%, #f6f6f6 100%)
 
             img
-                -webkit-filter $rolloverImageFilter
-                filter $rolloverImageFilter
+                opacity 1.0
 
         &.disabled
         &.disabled:hover
@@ -77,8 +77,7 @@ $dataAxisColor = #333333
             cursor default
 
             img
-                -webkit-filter $disabledImageFilter
-                filter $disabledImageFilter
+                opacity 0.2
 
     .isic-images-image-container
       overflow auto


### PR DESCRIPTION
Firefox seems to have trouble with the advanced SVG magic being used to recolor the images.

Instead of all that, this PR just uses opacity as a way to signal the (1) disabled state of a paging button and (2) rollover state of the same.

Fixes #134 