### PR TITLE
Eliminate the page size control

### DIFF
--- a/web_external/js/views/body/ImagesView/PagingPane.js
+++ b/web_external/js/views/body/ImagesView/PagingPane.js
@@ -116,15 +116,11 @@ isic.views.ImagesViewSubViews.PagingPane = Backbone.View.extend({
                     '/built/plugins/isic_archive/extra/img/' +
                     imgName + '.svg';
                 });
-            // Listen for page size adjustments
-            self.$el.find('#isic-images-pageSize').on('change', function () {
-                self.model.set('limit', this.value);
-                // Invalid values will be capped; update the field if that happens
-                var newLimit = self.model.get('limit');
-                if (newLimit !== this.value) {
-                    this.value = newLimit;
-                }
-            });
+            // Set the page size to 50.
+            //
+            // TODO: offer a pulldown menu with several page size options.
+            self.model.set('limit', 50);
+
             self.addedImages = true;
         }
 

--- a/web_external/stylesheets/body/imagesPage.styl
+++ b/web_external/stylesheets/body/imagesPage.styl
@@ -111,19 +111,6 @@ $dataAxisColor = #333333
         #isic-images-pagingTools
             align-items: center;
 
-            #isic-images-pageSizeControl
-                margin 1em
-                white-space nowrap
-
-                label
-                    margin 0
-                    vertical-align middle
-
-                input
-                    margin-left 1em
-                    text-align center
-                    width 4em
-
             .overview
                 font-weight bolder
                 color: $overviewColor

--- a/web_external/templates/body/imagesPage.jade
+++ b/web_external/templates/body/imagesPage.jade
@@ -9,9 +9,6 @@
         #isic-images-pagingTools.flexRow
           #isic-images-seekFirst.button
           #isic-images-seekPrev.button
-          #isic-images-pageSizeControl
-            label(for='#isic-images-pageSize') Page Size:
-            input#isic-images-pageSize(type='number',value='50',max='250',min='1',step='25')
           #isic-images-seekNext.button
           #isic-images-seekLast.button
           #isic-images-noPagingOrFilters.detailLabel


### PR DESCRIPTION
Set page size to 50 statically. Later we can use a dropdown menu to offer a few choices of page size.

Fixes #133 