### PR TITLE
Open image in new tab when double clicked

### DIFF
--- a/web_external/js/views/body/ImagesView/ImageWall.js
+++ b/web_external/js/views/body/ImagesView/ImageWall.js
@@ -257,6 +257,43 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
             .data(imageList, function (d) {
                 return d;
             });
+
+        // This click callback has to be defined here with a name because it
+        // must refer to itself.
+        var click = function (d) {
+            // Capture the target element for reference in the nested callback.
+            var that = this;
+
+            // This flag and nested callback will detect whether a second click
+            // arrives.
+            var doubleclick;
+            d3.select(that).on('click.second', function () {
+                doubleclick = true;
+            });
+
+            // This temporarily removes the outer callback from firing (since we
+            // don't want to wreck the careful state we're cultivating waiting
+            // for a possible second click).
+            d3.select(that).on('click', null);
+
+            // Allow 300 ms for a second click to be detected.
+            setTimeout(function () {
+                // When the 300 ms is up, remove the detector callback and
+                // reinstate the main click handler.
+                d3.select(that).on('click.second', null);
+                d3.select(that).on('click', click);
+
+                // If a double click was detected, then open the full size image
+                // in a new window; otherwise, toggle the selection state of the
+                // image.
+                if (doubleclick) {
+                    window.open('/api/v1/image/' + d + '/download?contentDisposition=inline');
+                } else {
+                    self.selectImage(d === self.model.get('selectedImageId') ? null : d);
+                }
+            }, 300);
+        };
+
         images.enter().append('image')
             .attr('preserveAspectRatio', 'xMinYMin');
         images.exit().remove();
@@ -281,9 +318,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
             y: function (d) {
                 return placementLookup[d].y;
             }
-        }).on('click', function (d) {
-            self.selectImage(d === self.model.get('selectedImageId') ? null : d);
-        });
+        }).on('click', click);
 
         // Draw the highlight rect
         var selectedImageId = self.model.get('selectedImageId');


### PR DESCRIPTION
This is done using a bit of hackery.

When a `dblclick` event is fired, it comes with two `click` events. To get around this, I've converted the click handler to a more complicated one that receives a click, waits a set interval for a second click, then dispatches the single-click behavior (toggle selected image) if there wasn't a second click, or the double-click behavior (open image in new tab) if there was.

The one pitfall of this approach is that you can't dispatch the single-click behavior until the detection interval has elapsed. I don't believe there's any way around this. If this is unacceptable, then we'll have to find an alternate input behavior besides double-click on which to display the full size image.

Fixes #137 