### PR TITLE
Make isic.events an alias for girder.events

### DIFF
--- a/web_external/js/init.js
+++ b/web_external/js/init.js
@@ -7,7 +7,7 @@ _.extend(isic, {
     collections: {},
     views: {},
     router: new Backbone.Router(),
-    events: _.clone(Backbone.Events)
+    events: girder.events
 });
 
 girder.router.enabled(false);


### PR DESCRIPTION
Make isic.events an alias for girder.events instead of a separate object. For
one, this ensures that triggering the 'g:appload.before' and 'g:appload.after'
events in main.js reach plugins that observe those events on girder.events, such
as the google_analytics plugin.

Note that the google_analytics plugin doesn't currently distinguish the root URL from the Girder web client and the web_external web client. For example, navigating to '/' and '/girder' will both result in a hit to '/' on Google Analytics. As another example, /girder/collection/... URLs show up as /collection/..., i.e. the /girder prefix is missing.