### PR TITLE
Lesion Images code cleanup

### DIFF
--- a/web_external/js/views/body/ImagesView/DatasetPane.js
+++ b/web_external/js/views/body/ImagesView/DatasetPane.js
@@ -2,7 +2,7 @@
 
 isic.views.ImagesViewSubViews = isic.views.ImagesViewSubViews || {};
 
-isic.views.ImagesViewSubViews.StudyPane = Backbone.View.extend({
+isic.views.ImagesViewSubViews.DatasetPane = Backbone.View.extend({
     initialize: function () {
         this.listenTo(this.model, 'change:overviewHistogram', this.render);
         this.listenTo(this.model, 'change:filteredSetHistogram', this.render);
@@ -12,10 +12,10 @@ isic.views.ImagesViewSubViews.StudyPane = Backbone.View.extend({
         var svg;
 
         if (!this.addedSvgElement) {
-            this.$el.html(isic.templates.imageStudyPage({
+            this.$el.html(isic.templates.imageDatasetPage({
                 title: 'Dataset'
             }));
-            var histogramContainer = this.$('.isic-image-study-histogram-container');
+            var histogramContainer = this.$('.isic-image-dataset-histogram-container');
             svg = d3.select(histogramContainer.get(0)).append('svg')
                 .attr('class', 'content');
             this.histogram = new isic.views.ImagesViewSubViews.IndividualHistogram({
@@ -29,14 +29,14 @@ isic.views.ImagesViewSubViews.StudyPane = Backbone.View.extend({
         }
         this.histogram.render();
 
-        // Add special listeners to open a modal about each study
+        // Add special listeners to open a modal about each dataset
         svg.select('.bins').selectAll('.bin')
             .on('click', _.bind(function (d) {
                 var dataset = this.model.datasetCollection.find(function (dataset) {
                     return dataset.name() === d;
                 });
                 console.log('TODO: show a modal, describing the ' +
-                    d + ' study (folder id: ' + dataset.id + ')');
+                    d + ' dataset (id: ' + dataset.id + ')');
             }, this));
         return this;
     }

--- a/web_external/js/views/body/ImagesView/HistogramPane.js
+++ b/web_external/js/views/body/ImagesView/HistogramPane.js
@@ -72,7 +72,7 @@ isic.views.ImagesViewSubViews.HistogramPane = Backbone.View.extend({
             .on('change', function (d) {
                 // this refers to the DOM element
                 var histogramId = window.shims.makeValidId(d + '_histogramContent');
-                var contentElement = self.$el.find('#' + histogramId);
+                var contentElement = self.$('#' + histogramId);
                 if (self.checked) {
                     contentElement.removeClass('collapsed');
                     // Update that particular histogram

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -6,10 +6,10 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
         'click .button': 'clearSelectedImage'
     },
 
-    initialize: function () {
-        this.image = new isic.models.ImageModel();
-        this.listenTo(this.image, 'g:fetched g:error', this.render);
-        this.listenTo(this.model, 'change:selectedImageId', this.selectedImageChanged);
+    initialize: function (settings) {
+        this.image = settings.image;
+
+        this.listenTo(this.image, 'changed:_id g:fetched g:error', this.render);
 
         this.segmentationsDisplayView = new isic.views.SegmentationsDisplayView({
             image: this.image,
@@ -65,18 +65,6 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
     },
 
     clearSelectedImage: function () {
-        this.model.set('selectedImageId', null);
-    },
-
-    selectedImageChanged: function () {
-        var imageId = this.model.get('selectedImageId');
-
-        // Fetch or clear image details
-        if (imageId) {
-            this.image.set('_id', imageId);
-            this.image.fetch();
-        } else {
-            this.image.clear();
-        }
+        this.image.clear();
     }
 });

--- a/web_external/js/views/body/ImagesView/ImageWall.js
+++ b/web_external/js/views/body/ImagesView/ImageWall.js
@@ -7,14 +7,15 @@ var imageSize = 128;
 isic.views.ImagesViewSubViews = isic.views.ImagesViewSubViews || {};
 
 isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
-    initialize: function () {
+    initialize: function (settings) {
         var self = this;
+        self.image = settings.image;
         self.imageCache = {};
         self.loadedImages = {};
         self.imageColumnLookup = {};
         self.imageColumns = [];
 
-        self.listenTo(self.model, 'change:selectedImageId', self.render);
+        self.listenTo(self.image, 'change:_id', self.render);
         self.listenTo(self.model, 'change:imageIds', self.setImages);
     },
     setImages: function () {
@@ -175,7 +176,11 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
     },
     selectImage: function (imageId) {
         var self = this;
-        self.model.set('selectedImageId', imageId);
+        if (imageId !== null) {
+            self.image.set('_id', imageId);
+        } else {
+            self.image.clear();
+        }
     },
     render: _.debounce(function () {
         var self = this;
@@ -289,7 +294,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
                 if (doubleclick) {
                     window.open('/api/v1/image/' + d + '/download?contentDisposition=inline');
                 } else {
-                    self.selectImage(d === self.model.get('selectedImageId') ? null : d);
+                    self.selectImage(d === self.image.id ? null : d);
                 }
             }, 300);
         };
@@ -302,7 +307,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
         }).attr('xlink:href', function (d) {
             return self.imageCache[d].src;
         }).attr('class', function (d) {
-            if (d === self.model.get('selectedImageId')) {
+            if (d === self.image.id) {
                 return 'selected';
             } else {
                 return null;
@@ -321,7 +326,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
         }).on('click', click);
 
         // Draw the highlight rect
-        var selectedImageId = self.model.get('selectedImageId');
+        var selectedImageId = self.image.id;
         if (selectedImageId) {
             svg.select('#highlightOutline')
                 .style('display', null)

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -8,7 +8,6 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
     defaults: {
         limit: 50,
         offset: 0,
-        selectedImageId: null,
         filter: {
             standard: {},
             custom: []
@@ -59,9 +58,6 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         self.listenTo(self, 'change:limit', self.updateCurrentPage);
         self.listenTo(self, 'change:offset', self.updateCurrentPage);
         self.listenTo(self, 'change:filter', self.updateFilters);
-        self.listenTo(self, 'change:imageIds', function () {
-            self.set('selectedImageId', null);
-        });
     },
     fetchDatasets: function () {
         var deferred = $.Deferred();

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -19,7 +19,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
                 label: 'count'
             }]
         },
-        studyHistogram: {
+        datasetHistogram: {
             __passedFilters__: [{
                 count: 0,
                 label: 'count'
@@ -45,9 +45,9 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         // before attempting to get histograms or image IDs
         $.when(this.fetchDatasets(), this.loadFilterGrammar())
             .then(_.bind(function () {
-                // We need the study names before getting any histograms
+                // We need the dataset names before getting any histograms
                 this.updateHistogram('overview');
-                // We need the study names and the filter grammar before getting
+                // We need the dataset names and the filter grammar before getting
                 // the filtered set or the current page (both the page of images
                 // and the page histogram)
                 this.updateFilters();

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -165,9 +165,9 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
     postProcessHistogram: function (histogram) {
         var self = this;
         var formatter = d3.format('0.3s');
-        Object.keys(histogram).forEach(function (attrName) {
-            histogram[attrName].forEach(function (bin, index) {
-                if (attrName === 'folderId') {
+        _.each(histogram, function (value, key) {
+            _.each(value, function (bin, index) {
+                if (key === 'folderId') {
                     bin.label = self.datasetCollection.get(bin.label).name();
                 } else if (_.isNumber(bin.lowBound) &&
                         _.isNumber(bin.highBound)) {
@@ -176,7 +176,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
                     // human-readable labels
                     bin.label = '[' + formatter(bin.lowBound) + ' - ' +
                         formatter(bin.highBound);
-                    if (index === histogram[attrName].length - 1) {
+                    if (index === value.length - 1) {
                         bin.label += ']';
                     } else {
                         bin.label += ')';

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -62,16 +62,18 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         });
     },
     getDatasetNames: function () {
-        return girder.restRequest({
-            path: 'dataset'
-        }).then(_.bind(function (datasetResp) {
+        var deferred = $.Deferred();
+        var datasetCollection = new isic.collections.DatasetCollection();
+        datasetCollection.once('g:changed', function () {
             this.datasetNameLookup = {};
             this.datasetIdLookup = {};
-            datasetResp.forEach(_.bind(function (dataset) {
-                this.datasetNameLookup[dataset['_id']] = dataset['name'];
-                this.datasetIdLookup[dataset['name']] = dataset['_id'];
-            }, this));
-        }, this));
+            datasetCollection.each(function (dataset) {
+                this.datasetNameLookup[dataset.id] = dataset.name();
+                this.datasetIdLookup[dataset.name()] = dataset.id;
+            }, this);
+            deferred.resolve();
+        }, this).fetch();
+        return deferred.promise();
     },
     loadFilterGrammar: function () {
         var self = this;

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -130,20 +130,19 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
 
         // Pass in filter settings
         pageDetails.filter = self.getFilterAstTree();
-        var imageListRequest = girder.restRequest({
-            path: 'image',
-            data: {
-                limit: pageDetails.limit,
-                offset: pageDetails.offset,
-                filter: self.getFilterAstTree()
-            }
-        }).then(function (resp) {
-            self.set('imageIds', resp.map(function (imageObj) {
-                return imageObj._id;
-            }));
+        var imagesDeferred = $.Deferred();
+        var images = new isic.collections.ImageCollection();
+        images.once('g:changed', _.bind(function () {
+            this.set('imageIds', images.pluck('_id'));
+            imagesDeferred.resolve();
+        }, this)).fetch({
+            limit: pageDetails.limit,
+            offset: pageDetails.offset,
+            filter: self.getFilterAstTree()
         });
+
         var histogramRequest = self.updateHistogram('page');
-        return $.when(imageListRequest, histogramRequest);
+        return $.when(imagesDeferred.promise(), histogramRequest);
     },
     getPageDetails: function (capLimit) {
         var self = this;

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -46,7 +46,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
 
         // Load the pegjs grammar and fetch the datasets
         // before attempting to get histograms or image IDs
-        jQuery.when(self.fetchDatasets(), self.loadFilterGrammar())
+        $.when(self.fetchDatasets(), self.loadFilterGrammar())
             .then(function () {
                 // We need the study names before getting any histograms
                 self.updateHistogram('overview');
@@ -72,7 +72,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
     },
     loadFilterGrammar: function () {
         var self = this;
-        return jQuery.ajax({
+        return $.ajax({
             url: girder.staticRoot + '/built/plugins/isic_archive/extra/query.pegjs',
             dataType: 'text',
             success: function (data) {
@@ -102,7 +102,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
     },
     updateFilters: function () {
         var self = this;
-        return jQuery.when(self.updateHistogram('filteredSet'),
+        return $.when(self.updateHistogram('filteredSet'),
                            self.updateCurrentPage());
     },
     updateCurrentPage: function () {
@@ -147,7 +147,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
             }));
         });
         var histogramRequest = self.updateHistogram('page');
-        return jQuery.when(imageListRequest, histogramRequest);
+        return $.when(imageListRequest, histogramRequest);
     },
     getPageDetails: function (capLimit) {
         var self = this;

--- a/web_external/js/views/body/ImagesView/IndividualHistogram.js
+++ b/web_external/js/views/body/ImagesView/IndividualHistogram.js
@@ -48,7 +48,7 @@ isic.views.ImagesViewSubViews.IndividualHistogram = Backbone.View.extend({
             .call(yAxis);
 
         // Move the special buttons into place and attach their events
-        this.$el.find('.selectAllBins').hide();
+        this.$('.selectAllBins').hide();
         /*
         svg.select('.selectAllBins')
             .attr('transform', 'translate(' +

--- a/web_external/js/views/body/ImagesView/PagingPane.js
+++ b/web_external/js/views/body/ImagesView/PagingPane.js
@@ -2,6 +2,12 @@
 isic.views.ImagesViewSubViews = isic.views.ImagesViewSubViews || {};
 
 isic.views.ImagesViewSubViews.PagingPane = Backbone.View.extend({
+    events: {
+        'click #isic-images-seekFirst': 'seekFirst',
+        'click #isic-images-seekPrev': 'seekPrev',
+        'click #isic-images-seekNext': 'seekNext',
+        'click #isic-images-seekLast': 'seekLast'
+    },
     initialize: function () {
         this.listenTo(this.model, 'change:imageIds', this.render);
         this.listenTo(this.model, 'change:filteredSetHistogram', this.render);
@@ -96,23 +102,12 @@ isic.views.ImagesViewSubViews.PagingPane = Backbone.View.extend({
         }
     },
     render: function () {
-        var self = this;
         if (!this.addedImages) {
-            // Sneaky hack: the image file name is part of the id; use the id to
-            // attach the correct src attribute, as well as the appropriate
-            // event listeners
-            d3.select(this.el).selectAll('.button')
-                .on('click', function () {
-                    var funcName = this.getAttribute('id').slice(12);
-                    self[funcName].apply(self, arguments);
-                })
-                .append('img')
-                .attr('src', function () {
-                    var imgName = this.parentNode.getAttribute('id').slice(12);
-                    return girder.staticRoot +
-                    '/built/plugins/isic_archive/extra/img/' +
-                    imgName + '.svg';
-                });
+            var imgRoot = girder.staticRoot + '/built/plugins/isic_archive/extra/img/';
+            this.$('.button').find('img').each(function (index) {
+                var name = $(this).data('name');
+                $(this).attr('src', imgRoot + name + '.svg');
+            });
             // Set the page size to 50.
             //
             // TODO: offer a pulldown menu with several page size options.

--- a/web_external/js/views/body/ImagesView/PagingPane.js
+++ b/web_external/js/views/body/ImagesView/PagingPane.js
@@ -3,20 +3,18 @@ isic.views.ImagesViewSubViews = isic.views.ImagesViewSubViews || {};
 
 isic.views.ImagesViewSubViews.PagingPane = Backbone.View.extend({
     initialize: function () {
-        var self = this;
-        self.listenTo(self.model, 'change:imageIds', self.render);
-        self.listenTo(self.model, 'change:filteredSetHistogram', self.render);
-        self.listenTo(self.model, 'change:offset', self.updateControls);
-        self.listenTo(self.model, 'change:limit', self.updateControls);
+        this.listenTo(this.model, 'change:imageIds', this.render);
+        this.listenTo(this.model, 'change:filteredSetHistogram', this.render);
+        this.listenTo(this.model, 'change:offset', this.updateControls);
+        this.listenTo(this.model, 'change:limit', this.updateControls);
     },
     renderBars: function () {
-        var self = this;
-        var pageDetails = self.model.getPageDetails(true);
+        var pageDetails = this.model.getPageDetails(true);
 
         // Scale for the bars
         var pageScale = d3.scale.linear()
           .domain([0, pageDetails.filteredSetCount])
-          .range([0, self.$('#isic-images-pagingBars').width()]);
+          .range([0, this.$('#isic-images-pagingBars').width()]);
 
         // Now draw the bars indicating the size and location of
         // the page within the current filtered set
@@ -47,8 +45,7 @@ isic.views.ImagesViewSubViews.PagingPane = Backbone.View.extend({
         });
     },
     updateControls: function () {
-        var self = this;
-        var pageDetails = self.model.getPageDetails(true);
+        var pageDetails = this.model.getPageDetails(true);
 
         var hasFilters = pageDetails.filteredSetCount < pageDetails.overviewCount;
         var hasPaging = pageDetails.limit < pageDetails.filteredSetCount;
@@ -100,11 +97,11 @@ isic.views.ImagesViewSubViews.PagingPane = Backbone.View.extend({
     },
     render: function () {
         var self = this;
-        if (!self.addedImages) {
+        if (!this.addedImages) {
             // Sneaky hack: the image file name is part of the id; use the id to
             // attach the correct src attribute, as well as the appropriate
             // event listeners
-            d3.select(self.el).selectAll('.button')
+            d3.select(this.el).selectAll('.button')
                 .on('click', function () {
                     var funcName = this.getAttribute('id').slice(12);
                     self[funcName].apply(self, arguments);
@@ -119,34 +116,30 @@ isic.views.ImagesViewSubViews.PagingPane = Backbone.View.extend({
             // Set the page size to 50.
             //
             // TODO: offer a pulldown menu with several page size options.
-            self.model.set('limit', 50);
+            this.model.set('limit', 50);
 
-            self.addedImages = true;
+            this.addedImages = true;
         }
 
-        self.updateControls();
-        self.renderBars();
+        this.updateControls();
+        this.renderBars();
 
         return this;
     },
     seekFirst: function () {
-        var self = this;
-        self.model.set('offset', 0);
+        this.model.set('offset', 0);
     },
     seekPrev: function () {
-        var self = this;
-        var offset = self.model.get('offset');
-        self.model.set('offset', offset - self.model.get('limit'));
+        var offset = this.model.get('offset');
+        this.model.set('offset', offset - this.model.get('limit'));
     },
     seekNext: function () {
-        var self = this;
-        var offset = self.model.get('offset');
-        self.model.set('offset', offset + self.model.get('limit'));
+        var offset = this.model.get('offset');
+        this.model.set('offset', offset + this.model.get('limit'));
     },
     seekLast: function () {
-        var self = this;
-        var details = self.model.getPageDetails(true);
-        self.model.set('offset',
+        var details = this.model.getPageDetails(true);
+        this.model.set('offset',
             Math.floor(details.filteredSetCount / details.limit) * details.limit);
     }
 });

--- a/web_external/js/views/body/ImagesView/PagingPane.js
+++ b/web_external/js/views/body/ImagesView/PagingPane.js
@@ -16,7 +16,7 @@ isic.views.ImagesViewSubViews.PagingPane = Backbone.View.extend({
         // Scale for the bars
         var pageScale = d3.scale.linear()
           .domain([0, pageDetails.filteredSetCount])
-          .range([0, self.$el.find('#isic-images-pagingBars').width()]);
+          .range([0, self.$('#isic-images-pagingBars').width()]);
 
         // Now draw the bars indicating the size and location of
         // the page within the current filtered set
@@ -55,31 +55,31 @@ isic.views.ImagesViewSubViews.PagingPane = Backbone.View.extend({
 
         // Disable / enable the appropriate paging buttons
         if (pageDetails.offset === 0) {
-            this.$el.find('#isic-images-seekPrev, #isic-images-seekFirst')
+            this.$('#isic-images-seekPrev, #isic-images-seekFirst')
                 .addClass('disabled');
         } else {
-            this.$el.find('#isic-images-seekPrev, #isic-images-seekFirst')
+            this.$('#isic-images-seekPrev, #isic-images-seekFirst')
                 .removeClass('disabled');
         }
         if (pageDetails.offset + pageDetails.limit === pageDetails.filteredSetCount) {
-            this.$el.find('#isic-images-seekNext, #isic-images-seekLast')
+            this.$('#isic-images-seekNext, #isic-images-seekLast')
                 .addClass('disabled');
         } else {
-            this.$el.find('#isic-images-seekNext, #isic-images-seekLast')
+            this.$('#isic-images-seekNext, #isic-images-seekLast')
                 .removeClass('disabled');
         }
 
         // Show the relevant explanatory label
-        this.$el.find('.detailLabel').hide();
+        this.$('.detailLabel').hide();
         var labelElement;
         if (hasFilters && hasPaging) {
-            labelElement = this.$el.find('#isic-images-hasFiltersAndPaging');
+            labelElement = this.$('#isic-images-hasFiltersAndPaging');
         } else if (hasFilters) {
-            labelElement = this.$el.find('#isic-images-hasFilters');
+            labelElement = this.$('#isic-images-hasFilters');
         } else if (hasPaging) {
-            labelElement = this.$el.find('#isic-images-hasPaging');
+            labelElement = this.$('#isic-images-hasPaging');
         } else {
-            labelElement = this.$el.find('#isic-images-noPagingOrFilters');
+            labelElement = this.$('#isic-images-noPagingOrFilters');
         }
         labelElement.show();
 

--- a/web_external/js/views/body/ImagesView/StudyPane.js
+++ b/web_external/js/views/body/ImagesView/StudyPane.js
@@ -35,8 +35,11 @@ isic.views.ImagesViewSubViews.StudyPane = Backbone.View.extend({
         // Add special listeners to open a modal about each study
         svg.select('.bins').selectAll('.bin')
             .on('click', function (d) {
+                var dataset = self.model.datasetCollection.find(function (dataset) {
+                    return dataset.name() === d;
+                });
                 console.log('TODO: show a modal, describing the ' +
-                    d + ' study (folder id: ' + self.model.datasetIdLookup[d] + ')');
+                    d + ' study (folder id: ' + dataset.id + ')');
             });
         return this;
     }

--- a/web_external/js/views/body/ImagesView/StudyPane.js
+++ b/web_external/js/views/body/ImagesView/StudyPane.js
@@ -4,43 +4,40 @@ isic.views.ImagesViewSubViews = isic.views.ImagesViewSubViews || {};
 
 isic.views.ImagesViewSubViews.StudyPane = Backbone.View.extend({
     initialize: function () {
-        var self = this;
-
-        self.listenTo(self.model, 'change:overviewHistogram', self.render);
-        self.listenTo(self.model, 'change:filteredSetHistogram', self.render);
-        self.listenTo(self.model, 'change:pageHistogram', self.render);
+        this.listenTo(this.model, 'change:overviewHistogram', this.render);
+        this.listenTo(this.model, 'change:filteredSetHistogram', this.render);
+        this.listenTo(this.model, 'change:pageHistogram', this.render);
     },
     render: function () {
-        var self = this;
         var svg;
 
-        if (!self.addedSvgElement) {
+        if (!this.addedSvgElement) {
             this.$el.html(isic.templates.imageStudyPage({
                 title: 'Dataset'
             }));
             var histogramContainer = this.$('.isic-image-study-histogram-container');
             svg = d3.select(histogramContainer.get(0)).append('svg')
                 .attr('class', 'content');
-            self.histogram = new isic.views.ImagesViewSubViews.IndividualHistogram({
+            this.histogram = new isic.views.ImagesViewSubViews.IndividualHistogram({
                 el: svg.node(),
-                model: self.model,
+                model: this.model,
                 attributeName: 'folderId'
             });
-            self.addedSvgElement = true;
+            this.addedSvgElement = true;
         } else {
-            svg = d3.select(self.el).select('svg.content');
+            svg = d3.select(this.el).select('svg.content');
         }
-        self.histogram.render();
+        this.histogram.render();
 
         // Add special listeners to open a modal about each study
         svg.select('.bins').selectAll('.bin')
-            .on('click', function (d) {
-                var dataset = self.model.datasetCollection.find(function (dataset) {
+            .on('click', _.bind(function (d) {
+                var dataset = this.model.datasetCollection.find(function (dataset) {
                     return dataset.name() === d;
                 });
                 console.log('TODO: show a modal, describing the ' +
                     d + ' study (folder id: ' + dataset.id + ')');
-            });
+            }, this));
         return this;
     }
 });

--- a/web_external/js/views/body/ImagesView/index.js
+++ b/web_external/js/views/body/ImagesView/index.js
@@ -15,12 +15,16 @@ isic.views.ImagesView = isic.View.extend({
         this.pagingPane = new isic.views.ImagesViewSubViews.PagingPane(params);
         this.imageDetailsPane = new isic.views.ImagesViewSubViews.ImageDetailsPane(params);
 
-        window.onresize = _.bind(function () {
-            this.render();
-        }, this);
+        $(window).on('resize.ImagesView', _.bind(this.render, this));
+
         this.listenTo(this.model, 'change:selectedImageId', this.toggleDetailsPane);
 
         this.render();
+    },
+    destroy: function () {
+        $(window).off('resize.ImagesView');
+
+        isic.View.prototype.destroy.call(this);
     },
     toggleDetailsPane: function () {
         if (this.model.get('selectedImageId') !== null) {

--- a/web_external/js/views/body/ImagesView/index.js
+++ b/web_external/js/views/body/ImagesView/index.js
@@ -2,56 +2,53 @@ isic.views.ImagesViewSubViews = isic.views.ImagesViewSubViews || {};
 
 isic.views.ImagesView = isic.View.extend({
     initialize: function () {
-        var self = this;
-        self.model = new isic.views.ImagesViewSubViews.ImagesViewModel();
+        this.model = new isic.views.ImagesViewSubViews.ImagesViewModel();
 
         // Initialize our subviews
         var params = {
-            model: self.model,
+            model: this.model,
             parentView: this
         };
-        self.studyPane = new isic.views.ImagesViewSubViews.StudyPane(params);
-        self.histogramPane = new isic.views.ImagesViewSubViews.HistogramPane(params);
-        self.imageWall = new isic.views.ImagesViewSubViews.ImageWall(params);
-        self.pagingPane = new isic.views.ImagesViewSubViews.PagingPane(params);
-        self.imageDetailsPane = new isic.views.ImagesViewSubViews.ImageDetailsPane(params);
+        this.studyPane = new isic.views.ImagesViewSubViews.StudyPane(params);
+        this.histogramPane = new isic.views.ImagesViewSubViews.HistogramPane(params);
+        this.imageWall = new isic.views.ImagesViewSubViews.ImageWall(params);
+        this.pagingPane = new isic.views.ImagesViewSubViews.PagingPane(params);
+        this.imageDetailsPane = new isic.views.ImagesViewSubViews.ImageDetailsPane(params);
 
-        window.onresize = function () {
-            self.render();
-        };
-        self.listenTo(self.model, 'change:selectedImageId', self.toggleDetailsPane);
+        window.onresize = _.bind(function () {
+            this.render();
+        }, this);
+        this.listenTo(this.model, 'change:selectedImageId', this.toggleDetailsPane);
 
-        self.render();
+        this.render();
     },
     toggleDetailsPane: function () {
-        var self = this;
-        if (self.model.get('selectedImageId') !== null) {
-            self.$el.find('#isic-images-imageDetailsPane').css('display', '');
+        if (this.model.get('selectedImageId') !== null) {
+            this.$el.find('#isic-images-imageDetailsPane').css('display', '');
         } else {
-            self.$el.find('#isic-images-imageDetailsPane').css('display', 'none');
+            this.$el.find('#isic-images-imageDetailsPane').css('display', 'none');
         }
     },
     render: function () {
-        var self = this;
-        if (!(self.addedTemplate)) {
-            self.$el.html(isic.templates.imagesPage({
+        if (!(this.addedTemplate)) {
+            this.$el.html(isic.templates.imagesPage({
                 staticRoot: girder.staticRoot
             }));
             window.shims.recolorImageFilters(['#00ABFF', '#444499', '#CCCCCC']);
-            self.studyPane.setElement(self.$el.find('#isic-images-studyPane')[0]);
-            self.histogramPane.setElement(self.$el.find('#isic-images-histogramPane')[0]);
-            self.imageWall.setElement(self.$el.find('#isic-images-imageWall')[0]);
-            self.pagingPane.setElement(self.$el.find('#isic-images-pagingPane')[0]);
-            self.imageDetailsPane.setElement(self.$el.find('#isic-images-imageDetailsPane')[0]);
-            self.addedTemplate = true;
+            this.studyPane.setElement(this.$el.find('#isic-images-studyPane')[0]);
+            this.histogramPane.setElement(this.$el.find('#isic-images-histogramPane')[0]);
+            this.imageWall.setElement(this.$el.find('#isic-images-imageWall')[0]);
+            this.pagingPane.setElement(this.$el.find('#isic-images-pagingPane')[0]);
+            this.imageDetailsPane.setElement(this.$el.find('#isic-images-imageDetailsPane')[0]);
+            this.addedTemplate = true;
         }
-        self.imageWall.render();
-        self.pagingPane.render();
-        self.studyPane.render();
-        self.histogramPane.render();
-        self.imageDetailsPane.render();
+        this.imageWall.render();
+        this.pagingPane.render();
+        this.studyPane.render();
+        this.histogramPane.render();
+        this.imageDetailsPane.render();
 
-        self.toggleDetailsPane();
+        this.toggleDetailsPane();
 
         return this;
     }

--- a/web_external/js/views/body/ImagesView/index.js
+++ b/web_external/js/views/body/ImagesView/index.js
@@ -24,9 +24,9 @@ isic.views.ImagesView = isic.View.extend({
     },
     toggleDetailsPane: function () {
         if (this.model.get('selectedImageId') !== null) {
-            this.$el.find('#isic-images-imageDetailsPane').css('display', '');
+            this.$('#isic-images-imageDetailsPane').css('display', '');
         } else {
-            this.$el.find('#isic-images-imageDetailsPane').css('display', 'none');
+            this.$('#isic-images-imageDetailsPane').css('display', 'none');
         }
     },
     render: function () {
@@ -35,11 +35,11 @@ isic.views.ImagesView = isic.View.extend({
                 staticRoot: girder.staticRoot
             }));
             window.shims.recolorImageFilters(['#00ABFF', '#444499', '#CCCCCC']);
-            this.studyPane.setElement(this.$el.find('#isic-images-studyPane')[0]);
-            this.histogramPane.setElement(this.$el.find('#isic-images-histogramPane')[0]);
-            this.imageWall.setElement(this.$el.find('#isic-images-imageWall')[0]);
-            this.pagingPane.setElement(this.$el.find('#isic-images-pagingPane')[0]);
-            this.imageDetailsPane.setElement(this.$el.find('#isic-images-imageDetailsPane')[0]);
+            this.studyPane.setElement(this.$('#isic-images-studyPane'));
+            this.histogramPane.setElement(this.$('#isic-images-histogramPane'));
+            this.imageWall.setElement(this.$('#isic-images-imageWall'));
+            this.pagingPane.setElement(this.$('#isic-images-pagingPane'));
+            this.imageDetailsPane.setElement(this.$('#isic-images-imageDetailsPane'));
             this.addedTemplate = true;
         }
         this.imageWall.render();

--- a/web_external/js/views/body/ImagesView/index.js
+++ b/web_external/js/views/body/ImagesView/index.js
@@ -10,7 +10,7 @@ isic.views.ImagesView = isic.View.extend({
             model: this.model,
             parentView: this
         };
-        this.studyPane = new isic.views.ImagesViewSubViews.StudyPane(params);
+        this.datasetPane = new isic.views.ImagesViewSubViews.DatasetPane(params);
         this.histogramPane = new isic.views.ImagesViewSubViews.HistogramPane(params);
         this.imageWall = new isic.views.ImagesViewSubViews.ImageWall(
             _.extend(_.clone(params), {
@@ -55,7 +55,7 @@ isic.views.ImagesView = isic.View.extend({
                 staticRoot: girder.staticRoot
             }));
             window.shims.recolorImageFilters(['#00ABFF', '#444499', '#CCCCCC']);
-            this.studyPane.setElement(this.$('#isic-images-studyPane'));
+            this.datasetPane.setElement(this.$('#isic-images-datasetPane'));
             this.histogramPane.setElement(this.$('#isic-images-histogramPane'));
             this.imageWall.setElement(this.$('#isic-images-imageWall'));
             this.pagingPane.setElement(this.$('#isic-images-pagingPane'));
@@ -64,7 +64,7 @@ isic.views.ImagesView = isic.View.extend({
         }
         this.imageWall.render();
         this.pagingPane.render();
-        this.studyPane.render();
+        this.datasetPane.render();
         this.histogramPane.render();
         this.imageDetailsPane.render();
 

--- a/web_external/js/views/body/ImagesView/shims/enums.js
+++ b/web_external/js/views/body/ImagesView/shims/enums.js
@@ -37,7 +37,7 @@ window.ENUMS.BIN_STATES = {
 window.ENUMS.SCHEMA = {
     'folderId': {
         'coerceToType': 'string',
-        'humanName': 'Study'
+        'humanName': 'Dataset'
     },
     'meta.clinical.benign_malignant': {
         'coerceToType': 'string',

--- a/web_external/templates/body/imagesPage.jade
+++ b/web_external/templates/body/imagesPage.jade
@@ -8,9 +8,13 @@
       .growing.flexColumn
         #isic-images-pagingTools.flexRow
           #isic-images-seekFirst.button
+            img(data-name='seekFirst')
           #isic-images-seekPrev.button
+            img(data-name='seekPrev')
           #isic-images-seekNext.button
+            img(data-name='seekNext')
           #isic-images-seekLast.button
+            img(data-name='seekLast')
           #isic-images-noPagingOrFilters.detailLabel
             | Showing all 
             span.page 10

--- a/web_external/templates/body/imagesPage.jade
+++ b/web_external/templates/body/imagesPage.jade
@@ -1,6 +1,6 @@
 #galleryContent.flexRow
   .fixedWidth.flexColumn
-    #isic-images-studyPane.pane
+    #isic-images-datasetPane.pane
     #isic-images-histogramPane.pane
   .growing.flexColumn
     #isic-images-pagingPane.pane.flexRow
@@ -16,27 +16,27 @@
           #isic-images-seekLast.button
             img(data-name='seekLast')
           #isic-images-noPagingOrFilters.detailLabel
-            | Showing all 
+            | Showing all
             span.page 10
             |  images in the archive.
           #isic-images-hasPaging.detailLabel
-            | Showing images 
+            | Showing images
             span.page 0 - 10
-            |  of 
+            |  of
             span.filteredSet 100
             |  total images.
           #isic-images-hasFilters.detailLabel
-            | Showing 
+            | Showing
             span.filteredSet 100
-            |  of the 
+            |  of the
             span.overview 1000
             |  total number of images in the archive.
           #isic-images-hasFiltersAndPaging.detailLabel
-            | Showing images 
+            | Showing images
             span.page 0 - 10
-            |  of 
+            |  of
             span.filteredSet 100
-            |  filtered images. There are 
+            |  filtered images. There are
             span.overview 1000
             |  total images in the archive (ignoring filters).
         #isic-images-pagingBars.flexRow

--- a/web_external/templates/widgets/imageDatasetPage.jade
+++ b/web_external/templates/widgets/imageDatasetPage.jade
@@ -1,0 +1,5 @@
+.isic-image-dataset-container
+  .attributeSection
+    .header
+      .title= title
+  .isic-image-dataset-histogram-container

--- a/web_external/templates/widgets/imageStudyPage.jade
+++ b/web_external/templates/widgets/imageStudyPage.jade
@@ -1,5 +1,0 @@
-.isic-image-study-container
-  .attributeSection
-    .header
-      .title= title
-  .isic-image-study-histogram-container


### PR DESCRIPTION
Some miscellaneous cleanup of the lesion images views to be more consistent with the rest of the app.

More could be done:
- continue replacing code like `var self = this`
- replace usage of `Object.keys`, `forEach`, `hasOwnProperty`, etc. with Underscore.js alternatives
- avoid directly assigning properties on `window`
- use more Jade templates
