### PR TITLE
New Annotation Study Results layout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,7 +140,18 @@ module.exports = function (grunt) {
             ],
             dest: staticDir + '/libs'
         });
-        defaultTasks.push('copy:' + pluginName + '_bower_libs');
+
+        grunt.config.set('copy.' + pluginName + '_node_modules', {
+            expand: true,
+            cwd: pluginDir + '/node_modules',
+            src: [
+                'select2/dist/css/select2.min.css',
+                'select2/dist/js/select2.min.js',
+                'select2-bootstrap-theme/dist/select2-bootstrap.min.css'
+            ],
+            dest: staticDir + '/libs'
+        });
+        defaultTasks.push('copy:' + pluginName + '_node_modules');
 
     };
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "url": "https://github.com/ImageMarkup/isic-archive.git"
   },
   "dependencies": {
-    "bower": "^1.7.7"
+    "bower": "^1.7.7",
+    "select2": "~4.0.3",
+    "select2-bootstrap-theme": ">=0.1.0-beta"
   },
   "devDependencies": {},
   "scripts": {

--- a/server/webroot.mako
+++ b/server/webroot.mako
@@ -17,6 +17,10 @@
         <link rel="stylesheet"
               href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
     % endfor
+    <link rel="stylesheet"
+          href="${staticRoot}/built/plugins/isic_archive/libs/select2/dist/css/select2.min.css">
+    <link rel="stylesheet"
+          href="${staticRoot}/built/plugins/isic_archive/libs/select2-bootstrap-theme/dist/select2-bootstrap.min.css">
     <link rel="icon"
           type="image/png"
           href="${staticRoot}/img/Girder_Favicon.png">
@@ -32,6 +36,7 @@
     % endfor
     <script src="${staticRoot}/built/plugins/isic_archive/isic_archive.min.js"></script>
     <script src="${staticRoot}/built/plugins/isic_archive/libs/pegjs/peg-0.10.0.min.js"></script>
+    <script src="${staticRoot}/built/plugins/isic_archive/libs/select2/dist/js/select2.min.js"></script>
     <script src="${staticRoot}/built/plugins/isic_archive/main.min.js"></script>
   </body>
 </html>

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -221,7 +221,6 @@ isic.views.StudyResultsGlobalFeaturesView = isic.View.extend({
 
     render: function () {
         this.$el.html(isic.templates.studyResultsGlobalFeaturesPage({
-            title: 'Global Features',
             hasFeatureset: !_.isUndefined(this.featureset.id),
             hasGlobalFeatures: !_.isEmpty(this.featureset.get('globalFeatures')),
             featureset: this.featureset
@@ -304,7 +303,6 @@ isic.views.StudyResultsLocalFeaturesView = isic.View.extend({
 
     render: function () {
         this.$el.html(isic.templates.studyResultsLocalFeaturesPage({
-            title: 'Local Features',
             hasFeatureset: !_.isUndefined(this.featureset.id),
             hasLocalFeatures: !_.isEmpty(this.featureset.get('localFeatures')),
             featureset: this.featureset

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -164,10 +164,10 @@ isic.views.StudyResultsSelectImageView = isic.View.extend({
     }
 });
 
-// View for a collection of users
+// View for a collection of users in a select tag
 isic.views.StudyResultsSelectUsersView = isic.View.extend({
     events: {
-        'click .isic-study-results-select-users-user-container': 'userSelected'
+        'change': 'userChanged'
     },
 
     initialize: function (options) {
@@ -176,15 +176,8 @@ isic.views.StudyResultsSelectUsersView = isic.View.extend({
         this.render();
     },
 
-    userSelected: function (event) {
-        event.preventDefault();
-
-        var target = $(event.target);
-
-        this.$('.isic-study-results-select-users-user-container').removeClass('active');
-        target.addClass('active');
-
-        this.trigger('changed', target.data('userId'));
+    userChanged: function () {
+        this.trigger('changed', this.$('select').val());
     },
 
     render: function () {
@@ -192,6 +185,11 @@ isic.views.StudyResultsSelectUsersView = isic.View.extend({
             models: this.collection.models,
             getName: this.formatUser
         }));
+
+        var select = this.$('#isic-study-results-select-users-select');
+        select.select2({
+            placeholder: 'Select a user...'
+        });
 
         return this;
     }
@@ -643,8 +641,8 @@ isic.views.StudyResultsView = isic.View.extend({
     },
 
     setContentContainerVisible: function(visible) {
-        var element = this.$('#isic-study-results-main-content');
-        this.setElementVisible(element, visible);
+        this.setElementVisible(this.$('#isic-study-results-main-content'), visible);
+        this.setElementVisible(this.$('#isic-study-results-select-user-container'), visible);
     }
 
 });

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -399,9 +399,15 @@ isic.views.StudyResultsImageView = isic.View.extend({
 // View for the results of an annotation study
 isic.views.StudyResultsView = isic.View.extend({
     events: {
+        // Update image visibility when image preview tab is activated
+        'shown.bs.tab #isic-study-results-image-preview-tab': function (event) {
+            this.imageView.$el.removeClass('hidden');
+            this.localFeaturesImageView.$el.addClass('hidden');
+        },
+
         // Update image visibility when global features tab is activated
         'shown.bs.tab #isic-study-results-global-features-tab': function (event) {
-            this.imageView.$el.removeClass('hidden');
+            this.imageView.$el.addClass('hidden');
             this.localFeaturesImageView.$el.addClass('hidden');
         },
 

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -91,7 +91,11 @@ isic.views.StudyResultsSelectStudyView = isic.View.extend({
             models: this.collection.models
         }));
 
-        this.$('#isic-study-results-select-study-select').focus();
+        var select = this.$('#isic-study-results-select-study-select');
+        select.select2({
+            placeholder: 'Select a study...'
+        });
+        select.focus();
 
         this.$('.isic-tooltip').tooltip({
             delay: 100
@@ -598,6 +602,9 @@ isic.views.StudyResultsView = isic.View.extend({
 
     render: function () {
         this.$el.html(isic.templates.studyResultsPage());
+
+        // Set select2 default options
+        $.fn.select2.defaults.set('theme', 'bootstrap');
 
         this.selectStudyView.setElement(
             this.$('#isic-study-results-select-study-container')).render();

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -127,6 +127,39 @@ isic.views.StudyResultsSelectImageView = isic.View.extend({
     }
 });
 
+// View for a collection of users
+isic.views.StudyResultsSelectUsersView = isic.View.extend({
+    events: {
+        'click .isic-study-results-select-users-user-container': 'userSelected'
+    },
+
+    initialize: function (options) {
+        this.listenTo(this.collection, 'reset', this.render);
+
+        this.render();
+    },
+
+    userSelected: function (event) {
+        event.preventDefault();
+
+        var target = $(event.target);
+
+        this.$('.isic-study-results-select-users-user-container').removeClass('active');
+        target.addClass('active');
+
+        this.trigger('changed', target.data('userId'));
+    },
+
+    render: function () {
+        this.$el.html(isic.templates.studyResultsSelectUsersPage({
+            models: this.collection.models,
+            getName: this.formatUser
+        }));
+
+        return this;
+    }
+});
+
 // Collection of global feature result models
 isic.collections.GlobalFeatureResultCollection = Backbone.Collection.extend({
     model: isic.models.GlobalFeatureResultModel,
@@ -367,9 +400,7 @@ isic.views.StudyResultsView = isic.View.extend({
             parentView: this
         });
 
-        this.selectUserView = new isic.views.StudyResultsSelectView({
-            title: 'User',
-            getName: this.formatUser,
+        this.selectUserView = new isic.views.StudyResultsSelectUsersView({
             collection: this.users,
             parentView: this
         });
@@ -412,8 +443,6 @@ isic.views.StudyResultsView = isic.View.extend({
 
         this.image.clear();
         this.user.clear();
-
-        this.selectUserView.setEnabled(false);
 
         this.annotation.clear();
         this.featureset.clear();

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -87,11 +87,15 @@ isic.views.StudyResultsSelectStudyView = isic.View.extend({
     },
 
     render: function () {
+        // Destroy previous select2
+        var select = this.$('#isic-study-results-select-study-select');
+        select.select2('destroy');
+
         this.$el.html(isic.templates.studyResultsSelectStudyPage({
             models: this.collection.models
         }));
 
-        var select = this.$('#isic-study-results-select-study-select');
+        select = this.$('#isic-study-results-select-study-select');
         select.select2({
             placeholder: 'Select a study...'
         });
@@ -181,12 +185,16 @@ isic.views.StudyResultsSelectUsersView = isic.View.extend({
     },
 
     render: function () {
+        // Destroy previous select2
+        var select = this.$('#isic-study-results-select-users-select');
+        select.select2('destroy');
+
         this.$el.html(isic.templates.studyResultsSelectUsersPage({
             models: this.collection.models,
             getName: this.formatUser
         }));
 
-        var select = this.$('#isic-study-results-select-users-select');
+        select = this.$('#isic-study-results-select-users-select');
         select.select2({
             placeholder: 'Select a user...'
         });
@@ -214,12 +222,16 @@ isic.views.StudyResultsSelectLocalFeaturesView = isic.View.extend({
     },
 
     render: function () {
+        // Destroy previous select2
+        var select = this.$('#isic-study-results-select-local-features-select');
+        select.select2('destroy');
+
         this.$el.html(isic.templates.studyResultsSelectLocalFeaturesPage({
             models: this.collection.models,
             featureAnnotated: this.featureAnnotated
         }));
 
-        var select = this.$('#isic-study-results-select-local-features-select');
+        select = this.$('#isic-study-results-select-local-features-select');
         select.select2({
             placeholder: 'Select a feature...'
         });

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -505,8 +505,9 @@ isic.views.StudyResultsView = isic.View.extend({
         this.annotation.clear();
         this.featureset.clear();
 
-        // Hide main container
-        this.$('#isic-study-results-main-container').addClass('hidden');
+        // Hide main and content containers
+        this.setMainContainerVisible(false);
+        this.setContentContainerVisible(false);
 
         // Fetch selected study
         this.study.set({'_id': studyId}).once('g:fetched', function () {
@@ -529,7 +530,7 @@ isic.views.StudyResultsView = isic.View.extend({
             }, this).fetch();
 
             // Show main container
-            this.$('#isic-study-results-main-container').removeClass('hidden');
+            this.setMainContainerVisible(true);
 
         }, this).fetch();
     },
@@ -538,6 +539,9 @@ isic.views.StudyResultsView = isic.View.extend({
         this.image.set('_id', imageId);
         this.annotation.clear();
         this.fetchAnnotation();
+
+        // Show content container
+        this.setContentContainerVisible(true);
     },
 
     userChanged: function (userId) {
@@ -588,7 +592,27 @@ isic.views.StudyResultsView = isic.View.extend({
             this.$('#isic-study-results-local-features-image-container')).render();
 
         return this;
+    },
+
+    setElementVisible: function (element, visible)
+    {
+        if (visible) {
+            element.removeClass('hidden');
+        } else {
+            element.addClass('hidden');
+        }
+    },
+
+    setMainContainerVisible: function(visible) {
+        var element = this.$('#isic-study-results-main-container');
+        this.setElementVisible(element, visible);
+    },
+
+    setContentContainerVisible: function(visible) {
+        var element = this.$('#isic-study-results-main-content');
+        this.setElementVisible(element, visible);
     }
+
 });
 
 isic.router.route('studyResults', 'studyResults', function (id) {

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -120,7 +120,8 @@ isic.views.StudyResultsSelectImageView = isic.View.extend({
     imageSelected: function (event) {
         event.preventDefault();
 
-        var target = $(event.target);
+        // currentTarget is the element that the event has bubbled up to
+        var target = $(event.currentTarget);
 
         this.$('.isic-study-results-select-image-image-container').removeClass('active');
         target.addClass('active');
@@ -130,7 +131,8 @@ isic.views.StudyResultsSelectImageView = isic.View.extend({
 
     render: function () {
         this.$el.html(isic.templates.studyResultsSelectImagePage({
-            models: this.collection.models
+            models: this.collection.models,
+            apiRoot: girder.apiRoot
         }));
 
         return this;

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -59,10 +59,6 @@ isic.views.StudyResultsSelectStudyView = isic.View.extend({
         }));
 
         return this;
-    },
-
-    _element: function () {
-        return this.$('select');
     }
 });
 

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -160,6 +160,41 @@ isic.views.StudyResultsSelectUsersView = isic.View.extend({
     }
 });
 
+// View for a collection of local features
+isic.views.StudyResultsSelectLocalFeaturesView = isic.View.extend({
+    events: {
+        'click .isic-study-results-select-local-features-feature-container': 'featureSelected'
+    },
+
+    initialize: function (options) {
+        this.featureAnnotated = options.featureAnnotated;
+
+        this.listenTo(this.collection, 'reset', this.render);
+
+        this.render();
+    },
+
+    featureSelected: function (event) {
+        event.preventDefault();
+
+        var target = $(event.target);
+
+        this.$('.isic-study-results-select-local-features-feature-container').removeClass('active');
+        target.addClass('active');
+
+        this.trigger('changed', target.data('featureId'));
+    },
+
+    render: function () {
+        this.$el.html(isic.templates.studyResultsSelectLocalFeaturesPage({
+            models: this.collection.models,
+            featureAnnotated: this.featureAnnotated
+        }));
+
+        return this;
+    }
+});
+
 // Collection of global feature result models
 isic.collections.GlobalFeatureResultCollection = Backbone.Collection.extend({
     model: isic.models.GlobalFeatureResultModel,
@@ -276,13 +311,9 @@ isic.views.StudyResultsLocalFeaturesView = isic.View.extend({
         this.listenTo(this.featureset, 'change', this.featuresetChanged);
         this.listenTo(this.annotation, 'change', this.annotationChanged);
 
-        this.selectFeatureView = new isic.views.StudyResultsSelectView({
-            title: 'Feature',
-            template: isic.templates.studyResultsLocalFeaturesSelectPage,
+        this.selectFeatureView = new isic.views.StudyResultsSelectLocalFeaturesView({
             collection: this.features,
-            extraTemplateParams: {
-                featureAnnotated: _.bind(this.featureAnnotated, this)
-            },
+            featureAnnotated: _.bind(this.featureAnnotated, this),
             parentView: this
         });
 

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -95,9 +95,14 @@ isic.views.StudyResultsSelectStudyView = isic.View.extend({
             models: this.collection.models
         }));
 
+        // Set up select box
+        var placeholder = 'Select a study...';
+        if (!this.collection.isEmpty()) {
+            placeholder += ' (' + this.collection.length + ' available)';
+        }
         select = this.$('#isic-study-results-select-study-select');
         select.select2({
-            placeholder: 'Select a study...'
+            placeholder: placeholder
         });
         select.focus();
 
@@ -194,9 +199,14 @@ isic.views.StudyResultsSelectUsersView = isic.View.extend({
             getName: this.formatUser
         }));
 
+        // Set up select box
+        var placeholder = 'No users available';
+        if (!this.collection.isEmpty()) {
+            placeholder = 'Select a user... (' + this.collection.length + ' available)';
+        }
         select = this.$('#isic-study-results-select-users-select');
         select.select2({
-            placeholder: 'Select a user...'
+            placeholder: placeholder
         });
 
         return this;
@@ -226,14 +236,24 @@ isic.views.StudyResultsSelectLocalFeaturesView = isic.View.extend({
         var select = this.$('#isic-study-results-select-local-features-select');
         select.select2('destroy');
 
+        // Create local collection of those features that are annotated
+        var collection = this.collection.clone();
+        collection.reset(collection.filter(_.bind(function (model) {
+            return this.featureAnnotated(model.id);
+        }, this)));
+
         this.$el.html(isic.templates.studyResultsSelectLocalFeaturesPage({
-            models: this.collection.models,
-            featureAnnotated: this.featureAnnotated
+            models: collection.models
         }));
 
+        // Set up select box
+        var placeholder = 'No features available';
+        if (!collection.isEmpty()) {
+            placeholder = 'Select a feature... (' + collection.length + ' available)';
+        }
         select = this.$('#isic-study-results-select-local-features-select');
         select.select2({
-            placeholder: 'Select a feature...'
+            placeholder: placeholder
         });
 
         return this;

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -266,7 +266,6 @@ isic.views.StudyResultsGlobalFeaturesView = isic.View.extend({
 
     render: function () {
         this.$el.html(isic.templates.studyResultsGlobalFeaturesPage({
-            hasFeatureset: !_.isUndefined(this.featureset.id),
             hasGlobalFeatures: !_.isEmpty(this.featureset.get('globalFeatures')),
             featureset: this.featureset
         }));
@@ -344,7 +343,6 @@ isic.views.StudyResultsLocalFeaturesView = isic.View.extend({
 
     render: function () {
         this.$el.html(isic.templates.studyResultsLocalFeaturesPage({
-            hasFeatureset: !_.isUndefined(this.featureset.id),
             hasLocalFeatures: !_.isEmpty(this.featureset.get('localFeatures')),
             featureset: this.featureset
         }));

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -84,6 +84,27 @@ isic.views.StudyResultsSelectStudyView = isic.View.extend({
     }
 });
 
+// View for study details
+isic.views.StudyResultsStudyDetailsView = isic.View.extend({
+    initialize: function (options) {
+        this.listenTo(this.model, 'change', this.render);
+
+        this.render();
+    },
+
+    render: function () {
+        var hasStudy = this.model.has('name');
+
+        this.$el.html(isic.templates.studyResultsStudyDetailPage({
+            model: this.model,
+            hasStudy: hasStudy,
+            formatUser: this.formatUser
+        }));
+
+        return this;
+    }
+});
+
 // View for a collection of images
 isic.views.StudyResultsSelectImageView = isic.View.extend({
     events: {
@@ -413,6 +434,11 @@ isic.views.StudyResultsView = isic.View.extend({
             parentView: this
         });
 
+        this.studyDetailsView = new isic.views.StudyResultsStudyDetailsView({
+            model: this.study,
+            parentView: this
+        });
+
         this.imageHeaderView = new isic.views.StudyResultsImageHeaderView({
             collection: this.images,
             study: this.study,
@@ -533,6 +559,8 @@ isic.views.StudyResultsView = isic.View.extend({
 
         this.selectStudyView.setElement(
             this.$('#isic-study-results-select-study-container')).render();
+        this.studyDetailsView.setElement(
+            this.$('#isic-study-results-study-details-container')).render();
         this.imageHeaderView.setElement(
             this.$('#isic-study-results-select-image-header')).render();
         this.selectImageView.setElement(

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -37,61 +37,32 @@ isic.collections.FeatureCollection = Backbone.Collection.extend({
     }
 });
 
-// Base view for a collection of models in a select tag
-isic.views.StudyResultsSelectView = isic.View.extend({
+// View for a collection of studies in a select tag
+isic.views.StudyResultsSelectStudyView = isic.View.extend({
     events: {
-        'change': 'modelChanged'
+        'change': 'studyChanged'
     },
 
     initialize: function (options) {
-        this.title = options.title;
-        this.template = _.has(options, 'template') ? options.template : isic.templates.studyResultsSelectView;
-        this.extraTemplateParams = _.has(options, 'extraTemplateParams') ? options.extraTemplateParams : {};
-        this.selectId = _.uniqueId('isic-study-results-select-view-select-');
-        this.getName = options.getName || this._defaultGetName;
         this.listenTo(this.collection, 'reset', this.render);
 
         this.render();
     },
 
-    modelChanged: function () {
-        this.trigger('changed', this._element().val());
-    },
-
-    setEnabled: function (val) {
-        if (val) {
-            this._element().removeAttr('disabled');
-        } else {
-            this._element().attr('disabled', 'disabled');
-        }
-    },
-
-    update: function () {
-        this.render();
-        this._element().selectedIndex = 0;
-        this.setEnabled(true);
+    studyChanged: function () {
+        this.trigger('changed', this.$('select').val());
     },
 
     render: function () {
-        var params = {
-            title: this.title,
-            selectId: this.selectId,
-            getName: this.getName,
+        this.$el.html(isic.templates.studyResultsSelectStudyPage({
             models: this.collection.models
-        };
-        _.extend(params, this.extraTemplateParams);
-
-        this.$el.html(this.template(params));
+        }));
 
         return this;
     },
 
     _element: function () {
         return this.$('select');
-    },
-
-    _defaultGetName: function (model) {
-        return model.name();
     }
 });
 
@@ -418,8 +389,7 @@ isic.views.StudyResultsView = isic.View.extend({
         this.annotation = new isic.models.AnnotationModel();
         this.featureImageModel = new isic.models.FeatureImageModel();
 
-        this.selectStudyView = new isic.views.StudyResultsSelectView({
-            title: 'Study',
+        this.selectStudyView = new isic.views.StudyResultsSelectStudyView({
             collection: this.studies,
             parentView: this
         });

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -586,7 +586,6 @@ isic.views.StudyResultsView = isic.View.extend({
 
             // Show main container
             this.setMainContainerVisible(true);
-
         }, this).fetch();
     },
 
@@ -656,8 +655,7 @@ isic.views.StudyResultsView = isic.View.extend({
         return this;
     },
 
-    setElementVisible: function (element, visible)
-    {
+    setElementVisible: function (element, visible) {
         if (visible) {
             element.removeClass('hidden');
         } else {

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -195,10 +195,10 @@ isic.views.StudyResultsSelectUsersView = isic.View.extend({
     }
 });
 
-// View for a collection of local features
+// View for a collection of local features in a select tag
 isic.views.StudyResultsSelectLocalFeaturesView = isic.View.extend({
     events: {
-        'click .isic-study-results-select-local-features-feature-container': 'featureSelected'
+        'change': 'featureChanged'
     },
 
     initialize: function (options) {
@@ -209,15 +209,8 @@ isic.views.StudyResultsSelectLocalFeaturesView = isic.View.extend({
         this.render();
     },
 
-    featureSelected: function (event) {
-        event.preventDefault();
-
-        var target = $(event.target);
-
-        this.$('.isic-study-results-select-local-features-feature-container').removeClass('active');
-        target.addClass('active');
-
-        this.trigger('changed', target.data('featureId'));
+    featureChanged: function () {
+        this.trigger('changed', this.$('select').val());
     },
 
     render: function () {
@@ -225,6 +218,11 @@ isic.views.StudyResultsSelectLocalFeaturesView = isic.View.extend({
             models: this.collection.models,
             featureAnnotated: this.featureAnnotated
         }));
+
+        var select = this.$('#isic-study-results-select-local-features-select');
+        select.select2({
+            placeholder: 'Select a feature...'
+        });
 
         return this;
     }

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -505,6 +505,9 @@ isic.views.StudyResultsView = isic.View.extend({
         this.annotation.clear();
         this.featureset.clear();
 
+        // Hide main container
+        this.$('#isic-study-results-main-container').addClass('hidden');
+
         // Fetch selected study
         this.study.set({'_id': studyId}).once('g:fetched', function () {
             // Populate images collection
@@ -524,6 +527,10 @@ isic.views.StudyResultsView = isic.View.extend({
             featureset.once('g:fetched', function () {
                 this.featureset.set(featureset.attributes);
             }, this).fetch();
+
+            // Show main container
+            this.$('#isic-study-results-main-container').removeClass('hidden');
+
         }, this).fetch();
     },
 

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -633,12 +633,12 @@ isic.views.StudyResultsView = isic.View.extend({
         }
     },
 
-    setMainContainerVisible: function(visible) {
+    setMainContainerVisible: function (visible) {
         var element = this.$('#isic-study-results-main-container');
         this.setElementVisible(element, visible);
     },
 
-    setContentContainerVisible: function(visible) {
+    setContentContainerVisible: function (visible) {
         this.setElementVisible(this.$('#isic-study-results-main-content'), visible);
         this.setElementVisible(this.$('#isic-study-results-select-user-container'), visible);
     }

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -551,9 +551,7 @@ isic.views.StudyResultsView = isic.View.extend({
     },
 
     render: function () {
-        this.$el.html(isic.templates.studyResultsPage({
-            title: 'Annotation Study Results'
-        }));
+        this.$el.html(isic.templates.studyResultsPage());
 
         this.selectStudyView.setElement(
             this.$('#isic-study-results-select-study-container')).render();

--- a/web_external/js/views/body/StudyResultsView.js
+++ b/web_external/js/views/body/StudyResultsView.js
@@ -78,6 +78,8 @@ isic.views.StudyResultsSelectStudyView = isic.View.extend({
             models: this.collection.models
         }));
 
+        this.$('#isic-study-results-select-study-select').focus();
+
         return this;
     }
 });

--- a/web_external/stylesheets/body/imagesPage.styl
+++ b/web_external/stylesheets/body/imagesPage.styl
@@ -13,7 +13,7 @@ $dataAxisColor = #333333
 #galleryContent
     position relative
     min-height 12em
-    height calc(100vh - 13em)
+    height calc(100vh - 8.2em)
     display flex
     width 100%
     flex-wrap nowrap

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -35,7 +35,7 @@
     flex-flow column
 
   #isic-study-results-select-image-container
-    min-width 250px
+    min-width 190px
     overflow auto
 
   #isic-study-results-select-user-container

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -35,7 +35,7 @@
     flex-flow column
 
   #isic-study-results-select-image-container
-    min-width 150px
+    min-width 155px
     overflow auto
 
   #isic-study-results-main-content

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -5,11 +5,12 @@
   height calc(100vh - 13em)
   overflow hidden
 
-  label
-    font-size 20px
-
   .nav-tabs
     font-size 18px
+
+  .isic-study-results-header
+    font-size 20px
+    font-weight bold
 
   .isic-study-results-flex-row
     display flex

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -56,5 +56,10 @@
     width 100%
     height 100%
 
+  .nav
+    li
+      a
+        padding 5px 10px
+
   .tab-content
     padding-top 3px

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -55,3 +55,6 @@
     object-fit contain
     width 100%
     height 100%
+
+  .tab-content
+    padding-top 3px

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -5,11 +5,8 @@
   height calc(100vh - 13em)
   overflow hidden
 
-  .nav-tabs
-    font-size 18px
-
   .isic-study-results-header
-    font-size 20px
+    font-size 16px
     font-weight bold
 
   .isic-study-results-flex-row
@@ -38,8 +35,11 @@
     flex-flow column
 
   #isic-study-results-select-image-container
-    min-width 190px
+    min-width 150px
     overflow auto
+
+  #isic-study-results-main-content
+    padding-left 10px
 
   #isic-study-results-select-user-container
     margin-bottom 10px

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -8,6 +8,9 @@
   label
     font-size 20px
 
+  .nav-tabs
+    font-size 18px
+
   .isic-study-results-flex-row
     display flex
     flex-flow row

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -1,6 +1,44 @@
-.isic-study-results-form-group
+.isic-study-results-container
+  display flex
+  flex-flow column
+  min-height 12em
+  height calc(100vh - 13em)
+  overflow hidden
+
   label
     font-size 20px
 
+  .isic-study-results-flex-row
+    display flex
+    flex-flow row
+
+  .isic-study-results-flex-column
+    display flex
+    flex-flow column
+
+  .isic-study-results-flex-grow
+    flex 1
+
+  .isic-study-results-main-container
+    overflow hidden
+
+  .isic-study-results-image-container
+    overflow auto
+    display flex
+    flex-flow column
+
+  #isic-study-results-select-image-container
+    min-width 250px
+    overflow auto
+
+  #isic-study-results-image-container
+  #isic-study-results-local-features-image-container
+    display flex
+
   .isic-study-results-image
+    flex 1
+    min-width 640px
+    min-height 480px
+    object-fit contain
     width 100%
+    height 100%

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -24,9 +24,6 @@
   .isic-study-results-pad
     padding 10px
 
-  #isic-study-results-study-details-container
-    padding-left 10px
-
   #isic-study-results-main-container
     overflow hidden
 

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -37,6 +37,9 @@
     min-width 250px
     overflow auto
 
+  #isic-study-results-select-user-container
+    margin-bottom 10px
+
   #isic-study-results-image-container
   #isic-study-results-local-features-image-container
     display flex

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -26,6 +26,9 @@
   .isic-study-results-pad
     padding 10px
 
+  #isic-study-results-study-details-container
+    padding-left 10px
+
   #isic-study-results-main-container
     overflow hidden
 

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -19,6 +19,9 @@
   .isic-study-results-flex-grow
     flex 1
 
+  .isic-study-results-pad
+    padding 10px
+
   .isic-study-results-main-container
     overflow hidden
 

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -2,7 +2,8 @@
   display flex
   flex-flow column
   min-height 12em
-  height calc(100vh - 13em)
+  // TODO Better way to calculate height
+  height calc(100vh - 8.15em)
   overflow hidden
 
   .isic-study-results-header

--- a/web_external/stylesheets/body/studyResultsPage.styl
+++ b/web_external/stylesheets/body/studyResultsPage.styl
@@ -26,7 +26,7 @@
   .isic-study-results-pad
     padding 10px
 
-  .isic-study-results-main-container
+  #isic-study-results-main-container
     overflow hidden
 
   .isic-study-results-image-container

--- a/web_external/stylesheets/layout.styl
+++ b/web_external/stylesheets/layout.styl
@@ -61,6 +61,21 @@ $textColor = #444
   padding 0 !important
 
 #isic-app-footer-container
+  display flex
   border-top 1px solid #eee
-  text-align center
   background-image linear-gradient(to bottom, #f6f6f6 0%, #fff 5px)
+  padding 5px 10px 0px 10px
+
+  ul
+    display flex
+    list-style none
+    padding 0px
+
+  // Add vertical line separator before list items, except the first
+  li + li
+    &:before
+      content '\2502'
+      padding 0em 0.5em
+
+  .isic-footer-info
+    flex 1

--- a/web_external/stylesheets/widgets/studyResultsGlobalFeaturesPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsGlobalFeaturesPage.styl
@@ -10,5 +10,7 @@
       padding-right 2em
       &.disabled
         color #aaa
+        code
+          color #aaa
     .isic-study-results-annotation-feature-value
       width 70%

--- a/web_external/stylesheets/widgets/studyResultsGlobalFeaturesPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsGlobalFeaturesPage.styl
@@ -2,11 +2,12 @@
   margin 0px 20px
 
 .isic-study-results-global-features-table
-  width 100%
+  width auto
 
   tbody
     .isic-study-results-annotation-feature-id
       width 30%
+      padding-right 2em
       &.disabled
         color #aaa
     .isic-study-results-annotation-feature-value

--- a/web_external/stylesheets/widgets/studyResultsLocalFeaturesPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsLocalFeaturesPage.styl
@@ -1,4 +1,6 @@
 .isic-study-results-local-features-content
+  display flex
+
   &>span
     margin-left 20px
 
@@ -19,3 +21,6 @@
 
 #isic-study-results-local-features-image-container
   margin-top 5px
+
+#isic-study-results-select-local-feature-container
+  flex 1

--- a/web_external/stylesheets/widgets/studyResultsSelectImagePage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectImagePage.styl
@@ -5,8 +5,7 @@
 
   // Individual image
   .isic-study-results-select-image-image-container
-    font-size 20px
-    padding 5px 0px
+    padding 5px 0
     border-bottom 1px solid #ddd
     cursor pointer
     user-select none
@@ -17,3 +16,13 @@
 
     &.active
       background-color #d3f4ff
+
+    *
+      vertical-align middle
+
+    span
+      margin-left 5px
+      font-size 20px
+
+    img
+      margin-left 10px

--- a/web_external/stylesheets/widgets/studyResultsSelectImagePage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectImagePage.styl
@@ -1,0 +1,19 @@
+@import 'nib'
+
+// Image container
+.isic-study-results-select-image-container
+
+  // Individual image
+  .isic-study-results-select-image-image-container
+    font-size 20px
+    padding 5px 0px
+    border-bottom 1px solid #ddd
+    cursor pointer
+    user-select none
+    color #444
+
+    &:hover
+      background-color #e7e7e7
+
+    &.active
+      background-color #d3f4ff

--- a/web_external/stylesheets/widgets/studyResultsSelectImagePage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectImagePage.styl
@@ -5,7 +5,7 @@
 
   // Individual image
   .isic-study-results-select-image-image-container
-    padding 5px 0
+    padding 3px 0
     border-bottom 1px solid #ddd
     cursor pointer
     user-select none
@@ -22,7 +22,7 @@
 
     span
       margin-left 5px
-      font-size 20px
 
     img
       margin-left 10px
+      margin-right 5px

--- a/web_external/stylesheets/widgets/studyResultsSelectLocalFeaturesPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectLocalFeaturesPage.styl
@@ -1,21 +1,5 @@
-@import 'nib'
-
 .isic-study-results-select-local-features-container
-  display flex
-  flex-flow row wrap
 
-  .isic-study-results-select-local-features-feature-container
-    font-size 14px
-    padding 3px 10px
-    border 1px solid #ddd
-    border-radius 10px
-    margin 3px 5px
-    cursor pointer
-    color #444
-    user-select none
-
-    &:hover
-      background-color #e7e7e7
-
-    &.active
-      background-color #d3f4ff
+  select
+    // Note that this might not apply, see https://select2.github.io/examples.html#responsive
+    width 100%

--- a/web_external/stylesheets/widgets/studyResultsSelectLocalFeaturesPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectLocalFeaturesPage.styl
@@ -1,0 +1,21 @@
+@import 'nib'
+
+.isic-study-results-select-local-features-container
+  display flex
+  flex-flow row wrap
+
+  .isic-study-results-select-local-features-feature-container
+    font-size 14px
+    padding 3px 10px
+    border 1px solid #ddd
+    border-radius 10px
+    margin 3px 5px
+    cursor pointer
+    color #444
+    user-select none
+
+    &:hover
+      background-color #e7e7e7
+
+    &.active
+      background-color #d3f4ff

--- a/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
@@ -1,6 +1,5 @@
 .isic-study-results-select-study-container
   display flex
-  align-items baseline
   margin-right 20px
   margin-bottom 10px
 
@@ -9,4 +8,6 @@
 
   select
     width 450px
-    margin-right 5px
+
+   .isic-study-results-select-study-details-button
+     margin-left 5px

--- a/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
@@ -1,3 +1,5 @@
 .isic-study-results-select-study-container
+  margin-right 20px
+
   select
     width 450px

--- a/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
@@ -1,10 +1,12 @@
 .isic-study-results-select-study-container
   display flex
+  align-items center
   margin-right 20px
   margin-bottom 10px
 
   label
     padding-right 5px
+    margin 0px
 
   select
     width 450px

--- a/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
@@ -9,3 +9,4 @@
 
   select
     width 450px
+    margin-right 5px

--- a/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
@@ -1,5 +1,11 @@
 .isic-study-results-select-study-container
+  display flex
+  align-items baseline
   margin-right 20px
+  margin-bottom 10px
+
+  label
+    padding-right 5px
 
   select
     width 450px

--- a/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectStudyPage.styl
@@ -1,0 +1,3 @@
+.isic-study-results-select-study-container
+  select
+    width 450px

--- a/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
@@ -5,11 +5,10 @@
   flex-flow row wrap
 
   .isic-study-results-select-users-user-container
-    font-size 20px
-    padding 10px
+    padding 2px 10px
     border 1px solid #ddd
     border-radius 10px
-    margin 5px
+    margin 2px
     cursor pointer
     color #444
     user-select none

--- a/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
@@ -1,20 +1,6 @@
 @import 'nib'
 
 .isic-study-results-select-users-container
-  display flex
-  flex-flow row wrap
 
-  .isic-study-results-select-users-user-container
-    padding 2px 10px
-    border 1px solid #ddd
-    border-radius 10px
-    margin 2px
-    cursor pointer
-    color #444
-    user-select none
-
-    &:hover
-      background-color #e7e7e7
-
-    &.active
-      background-color #d3f4ff
+  select
+    width 450px

--- a/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
@@ -1,4 +1,11 @@
 .isic-study-results-select-users-container
+  display flex
+  align-items center
+  margin-bottom 10px
+
+  label
+    padding-right 5px
+    margin 0px
 
   select
     width 450px

--- a/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
@@ -1,5 +1,3 @@
-@import 'nib'
-
 .isic-study-results-select-users-container
 
   select

--- a/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsSelectUsersPage.styl
@@ -1,0 +1,21 @@
+@import 'nib'
+
+.isic-study-results-select-users-container
+  display flex
+  flex-flow row wrap
+
+  .isic-study-results-select-users-user-container
+    font-size 20px
+    padding 10px
+    border 1px solid #ddd
+    border-radius 10px
+    margin 5px
+    cursor pointer
+    color #444
+    user-select none
+
+    &:hover
+      background-color #e7e7e7
+
+    &.active
+      background-color #d3f4ff

--- a/web_external/stylesheets/widgets/studyResultsStudyDetailPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsStudyDetailPage.styl
@@ -1,0 +1,9 @@
+.isic-study-results-study-details-container
+
+  .isic-study-results-study-details-table
+    width auto
+    margin-bottom 0px
+
+    .isic-study-results-study-details-table-label
+      font-weight bold
+      width 100px

--- a/web_external/stylesheets/widgets/studyResultsStudyDetailPage.styl
+++ b/web_external/stylesheets/widgets/studyResultsStudyDetailPage.styl
@@ -7,3 +7,7 @@
     .isic-study-results-study-details-table-label
       font-weight bold
       width 100px
+
+    tr:first-child
+      td
+        border-top 0px

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -20,7 +20,7 @@
       // Image container
       #isic-study-results-select-image-container
 
-    .isic-study-results-flex-column.isic-study-results-flex-grow.isic-study-results-pad
+    #isic-study-results-main-content.isic-study-results-flex-column.isic-study-results-flex-grow.isic-study-results-pad.hidden
 
       // User container
       .isic-study-results-header Users

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -1,7 +1,5 @@
 .isic-study-results-container
 
-  h2.isic-page-title= title
-
   // Study row
   .isic-study-results-flex-row
 

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -2,10 +2,16 @@
 
   h2.isic-page-title= title
 
-  // Study container
-  .isic-study-results-pad#isic-study-results-select-study-container
+  // Study row
+  .isic-study-results-flex-row
 
-  .isic-study-results-flex-row.isic-study-results-main-container
+    // Study container
+    #isic-study-results-select-study-container
+
+    // Study details container
+    .isic-study-results-flex-grow.isic-study-results-pad#isic-study-results-study-details-container
+
+  .isic-study-results-flex-row.isic-study-results-flex-grow.isic-study-results-main-container
 
     // Image column
     .isic-study-results-flex-column.isic-study-results-pad

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -6,6 +6,8 @@
     // Study container
     #isic-study-results-select-study-container
 
+    // User container
+    #isic-study-results-select-user-container.hidden
 
   #isic-study-results-main-container.isic-study-results-flex-row.isic-study-results-flex-grow.hidden
 
@@ -19,10 +21,6 @@
       #isic-study-results-select-image-container
 
     #isic-study-results-main-content.isic-study-results-flex-column.isic-study-results-flex-grow.hidden
-
-      // User container
-      .isic-study-results-header Users
-      #isic-study-results-select-user-container
 
       // Tabs
       ul.nav.nav-tabs

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -2,7 +2,7 @@
 // TODO: Make header appearance consistent; don't abuse 'label' for Image header
 // TODO: Dropdowns shouldn't fill width
 // TODO: Global feature table shouldn't expand to fill width
-// TODO: New user selection interface
+// TODO: Allow selecting multiple users
 // TODO: Add study details
 // TODO: Add image metadata (i.e. number of annotations, raters)
 // TODO: Add image thumbnails
@@ -28,6 +28,7 @@
     .isic-study-results-flex-column.isic-study-results-flex-grow
 
       // User container
+      label Users
       #isic-study-results-select-user-container
 
       // Global/local features tabs

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -6,8 +6,6 @@
     // Study container
     #isic-study-results-select-study-container
 
-    // Study details container
-    #isic-study-results-study-details-container.isic-study-results-flex-grow
 
   #isic-study-results-main-container.isic-study-results-flex-row.isic-study-results-flex-grow.hidden
 

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -19,7 +19,7 @@
     .isic-study-results-flex-column.isic-study-results-flex-grow.isic-study-results-pad
 
       // User container
-      label Users
+      .isic-study-results-header Users
       #isic-study-results-select-user-container
 
       // Global/local features tabs

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -12,7 +12,7 @@
   #isic-study-results-main-container.isic-study-results-flex-row.isic-study-results-flex-grow.hidden
 
     // Image column
-    .isic-study-results-flex-column.isic-study-results-pad
+    .isic-study-results-flex-column
 
       // Image header
       #isic-study-results-select-image-header
@@ -20,7 +20,7 @@
       // Image container
       #isic-study-results-select-image-container
 
-    #isic-study-results-main-content.isic-study-results-flex-column.isic-study-results-flex-grow.isic-study-results-pad.hidden
+    #isic-study-results-main-content.isic-study-results-flex-column.isic-study-results-flex-grow.hidden
 
       // User container
       .isic-study-results-header Users

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -26,17 +26,21 @@
       .isic-study-results-header Users
       #isic-study-results-select-user-container
 
-      // Global/local features tabs
+      // Tabs
       ul.nav.nav-tabs
         li.active
+          a(data-toggle="tab" href='#isic-study-results-image-preview-tab-content')#isic-study-results-image-preview-tab Image Preview
+        li
           a(data-toggle="tab" href='#isic-study-results-global-features-tab-content')#isic-study-results-global-features-tab Global Features
         li
           a(data-toggle="tab" href='#isic-study-results-local-features-tab-content')#isic-study-results-local-features-tab Local Features
 
-      // Content of global/local features tabs
+      // Tab content
       .tab-content.isic-study-results-pad
 
-        .tab-pane.active#isic-study-results-global-features-tab-content
+        .tab-pane.active#isic-study-results-image-preview-tab-content
+
+        .tab-pane#isic-study-results-global-features-tab-content
           #isic-study-results-global-features-container
 
         .tab-pane#isic-study-results-local-features-tab-content

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -1,11 +1,3 @@
-// TODO: Make header appearance consistent; don't abuse 'label' for Image header
-// TODO: Allow selecting multiple users
-// TODO: Add study details
-// TODO: Add image metadata (i.e. number of annotations, raters)
-// TODO: Add image thumbnails
-// TODO: Improve initial display, before making selections
-// TODO: Loading indicators?
-
 .isic-study-results-container
 
   h2.isic-page-title= title

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -7,7 +7,7 @@
     #isic-study-results-select-study-container
 
     // Study details container
-    .isic-study-results-flex-grow.isic-study-results-pad#isic-study-results-study-details-container
+    #isic-study-results-study-details-container.isic-study-results-flex-grow
 
   #isic-study-results-main-container.isic-study-results-flex-row.isic-study-results-flex-grow.hidden
 

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -9,7 +9,9 @@
 
     // Image column
     .isic-study-results-flex-column.isic-study-results-pad
-      label Image
+
+      // Image header
+      #isic-study-results-select-image-header
 
       // Image container
       #isic-study-results-select-image-container

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -9,7 +9,7 @@
     // Study details container
     .isic-study-results-flex-grow.isic-study-results-pad#isic-study-results-study-details-container
 
-  .isic-study-results-flex-row.isic-study-results-flex-grow.isic-study-results-main-container
+  #isic-study-results-main-container.isic-study-results-flex-row.isic-study-results-flex-grow.hidden
 
     // Image column
     .isic-study-results-flex-column.isic-study-results-pad

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -1,18 +1,56 @@
-.isic-form-page.isic-study-results-container
+// TODO: Spacing between sections
+// TODO: Make header appearance consistent; don't abuse 'label' for Image header
+// TODO: Dropdowns shouldn't fill width
+// TODO: Global feature table shouldn't expand to fill width
+// TODO: New user selection interface
+// TODO: Add study details
+// TODO: Add image metadata (i.e. number of annotations, raters)
+// TODO: Add image thumbnails
+// TODO: Improve initial display, before making selections
+// TODO: Loading indicators?
+
+.isic-study-results-container
+
   h2.isic-page-title= title
 
-  .isic-form-container
-    .isic-form-group.isic-study-results-form-group
+  // Study container
+  #isic-study-results-select-study-container
 
-      #isic-study-results-select-study-container
+  .isic-study-results-flex-row.isic-study-results-main-container
+
+    // Image column
+    .isic-study-results-flex-column
+      label Image
+
+      // Image container
       #isic-study-results-select-image-container
+
+    .isic-study-results-flex-column.isic-study-results-flex-grow
+
+      // User container
       #isic-study-results-select-user-container
 
-    .isic-form-group.isic-study-results-form-group
-      #isic-study-results-global-features-container
+      // Global/local features tabs
+      ul.nav.nav-tabs.nav-justified
+        li.active
+          a(data-toggle="tab" href='#isic-study-results-global-features-tab-content')#isic-study-results-global-features-tab Global Features
+        li
+          a(data-toggle="tab" href='#isic-study-results-local-features-tab-content')#isic-study-results-local-features-tab Local Features
 
-    .isic-form-group.isic-study-results-form-group
-      #isic-study-results-local-features-container
+      // Content of global/local features tabs
+      .tab-content
 
-    .isic-form-group.isic-study-results-form-group
-      #isic-study-results-image-container
+        .tab-pane.active#isic-study-results-global-features-tab-content
+          #isic-study-results-global-features-container
+
+        .tab-pane#isic-study-results-local-features-tab-content
+          #isic-study-results-local-features-container
+
+      // Image container
+      .isic-study-results-flex-grow.isic-study-results-image-container
+
+        // Local features image container
+        .isic-study-results-flex-grow.hidden#isic-study-results-local-features-image-container
+
+        // Image container
+        .isic-study-results-flex-grow#isic-study-results-image-container

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -1,5 +1,4 @@
 // TODO: Make header appearance consistent; don't abuse 'label' for Image header
-// TODO: Dropdowns shouldn't fill width
 // TODO: Allow selecting multiple users
 // TODO: Add study details
 // TODO: Add image metadata (i.e. number of annotations, raters)

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -36,7 +36,7 @@
           a(data-toggle="tab" href='#isic-study-results-local-features-tab-content')#isic-study-results-local-features-tab Local Features
 
       // Tab content
-      .tab-content.isic-study-results-pad
+      .tab-content
 
         .tab-pane.active#isic-study-results-image-preview-tab-content
 

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -1,6 +1,5 @@
 // TODO: Make header appearance consistent; don't abuse 'label' for Image header
 // TODO: Dropdowns shouldn't fill width
-// TODO: Global feature table shouldn't expand to fill width
 // TODO: Allow selecting multiple users
 // TODO: Add study details
 // TODO: Add image metadata (i.e. number of annotations, raters)

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -1,4 +1,3 @@
-// TODO: Spacing between sections
 // TODO: Make header appearance consistent; don't abuse 'label' for Image header
 // TODO: Dropdowns shouldn't fill width
 // TODO: Global feature table shouldn't expand to fill width
@@ -14,18 +13,18 @@
   h2.isic-page-title= title
 
   // Study container
-  #isic-study-results-select-study-container
+  .isic-study-results-pad#isic-study-results-select-study-container
 
   .isic-study-results-flex-row.isic-study-results-main-container
 
     // Image column
-    .isic-study-results-flex-column
+    .isic-study-results-flex-column.isic-study-results-pad
       label Image
 
       // Image container
       #isic-study-results-select-image-container
 
-    .isic-study-results-flex-column.isic-study-results-flex-grow
+    .isic-study-results-flex-column.isic-study-results-flex-grow.isic-study-results-pad
 
       // User container
       label Users
@@ -39,7 +38,7 @@
           a(data-toggle="tab" href='#isic-study-results-local-features-tab-content')#isic-study-results-local-features-tab Local Features
 
       // Content of global/local features tabs
-      .tab-content
+      .tab-content.isic-study-results-pad
 
         .tab-pane.active#isic-study-results-global-features-tab-content
           #isic-study-results-global-features-container

--- a/web_external/templates/body/studyResultsPage.jade
+++ b/web_external/templates/body/studyResultsPage.jade
@@ -31,7 +31,7 @@
       #isic-study-results-select-user-container
 
       // Global/local features tabs
-      ul.nav.nav-tabs.nav-justified
+      ul.nav.nav-tabs
         li.active
           a(data-toggle="tab" href='#isic-study-results-global-features-tab-content')#isic-study-results-global-features-tab Global Features
         li

--- a/web_external/templates/layout/layoutFooter.jade
+++ b/web_external/templates/layout/layoutFooter.jade
@@ -1,11 +1,17 @@
-.g-footer-links
-  a#g-contact-link(href="mailto:admin@isic-archive.com") Contact
-  a(href="#{apiRoot}") Web API
-  a#g-bug-link(href="https://github.com/ImageMarkup/isic-archive/issues/new") Report a bug
 
+.isic-footer-info
+  ul
+    li
+      | &copy; Kitware, Inc.
+    li
+      | Powered by
+      a#g-about-link(href="http://girder.readthedocs.org/en/latest/user-guide.html")  Girder
 
-.g-footer-info
-  | Powered by
-  a#g-about-link(href="http://girder.readthedocs.org/en/latest/user-guide.html")  Girder
-  br
-  | &copy; Kitware, Inc.
+.isic-footer-links
+  ul
+    li
+      a#g-contact-link(href="mailto:admin@isic-archive.com") Contact
+    li
+      a(href="#{apiRoot}") Web API
+    li
+      a#g-bug-link(href="https://github.com/ImageMarkup/isic-archive/issues/new") Report a bug

--- a/web_external/templates/widgets/studyResultsFeatureImagePage.jade
+++ b/web_external/templates/widgets/studyResultsFeatureImagePage.jade
@@ -1,3 +1,2 @@
-.isic-study-results-feature-image-container
-  if imageUrl
-    img.isic-study-results-image(src=imageUrl)
+if imageUrl
+  img.isic-study-results-image(src=imageUrl)

--- a/web_external/templates/widgets/studyResultsGlobalFeaturesPage.jade
+++ b/web_external/templates/widgets/studyResultsGlobalFeaturesPage.jade
@@ -1,7 +1,5 @@
 if hasFeatureset
-  h4 #{title} (#{featureset.name()}, version #{featureset.get('version')})
-else
-  h4 #{title}
+  h4 Featureset: #{featureset.name()}, version #{featureset.get('version')}
 
 .isic-study-results-global-features-content
   if hasGlobalFeatures

--- a/web_external/templates/widgets/studyResultsGlobalFeaturesPage.jade
+++ b/web_external/templates/widgets/studyResultsGlobalFeaturesPage.jade
@@ -1,6 +1,3 @@
-if hasFeatureset
-  h4 Featureset: #{featureset.name()}, version #{featureset.get('version')}
-
 .isic-study-results-global-features-content
   if hasGlobalFeatures
     #isic-study-results-global-features-table

--- a/web_external/templates/widgets/studyResultsGlobalFeaturesTable.jade
+++ b/web_external/templates/widgets/studyResultsGlobalFeaturesTable.jade
@@ -7,6 +7,6 @@ table.table.table-condensed.isic-study-results-global-features-table
     each feature in features
       tr
         td.isic-study-results-annotation-feature-id(title="#{feature.get('name')}", class={disabled: !feature.has('resultName')})
-          = feature.id
+          code= feature.id
         td.isic-study-results-annotation-feature-value(title="#{feature.get('resultId')}")
           = feature.get('resultName')

--- a/web_external/templates/widgets/studyResultsImageHeaderPage.jade
+++ b/web_external/templates/widgets/studyResultsImageHeaderPage.jade
@@ -1,5 +1,5 @@
 .isic-study-results-image-header-container
   .isic-study-results-header
-    | Images
+    | Images:
     if hasStudy
-      | &nbsp;(#{numImages})
+      span.badge.pull-right= numImages

--- a/web_external/templates/widgets/studyResultsImageHeaderPage.jade
+++ b/web_external/templates/widgets/studyResultsImageHeaderPage.jade
@@ -2,4 +2,4 @@
   .isic-study-results-header
     | Images
     if hasStudy
-      &nbsp;(#{numImages})
+      | &nbsp;(#{numImages})

--- a/web_external/templates/widgets/studyResultsImageHeaderPage.jade
+++ b/web_external/templates/widgets/studyResultsImageHeaderPage.jade
@@ -1,0 +1,5 @@
+.isic-study-results-image-header-container
+  label
+    | Images
+    if hasStudy
+      &nbsp;(#{numImages})

--- a/web_external/templates/widgets/studyResultsImageHeaderPage.jade
+++ b/web_external/templates/widgets/studyResultsImageHeaderPage.jade
@@ -1,5 +1,5 @@
 .isic-study-results-image-header-container
-  label
+  .isic-study-results-header
     | Images
     if hasStudy
       &nbsp;(#{numImages})

--- a/web_external/templates/widgets/studyResultsImagePage.jade
+++ b/web_external/templates/widgets/studyResultsImagePage.jade
@@ -1,3 +1,2 @@
-.isic-study-results-image-container
-  if imageUrl
-    img.isic-study-results-image(src=imageUrl)
+if imageUrl
+  img.isic-study-results-image(src=imageUrl)

--- a/web_external/templates/widgets/studyResultsLocalFeaturesPage.jade
+++ b/web_external/templates/widgets/studyResultsLocalFeaturesPage.jade
@@ -1,7 +1,5 @@
 - var hasFeaturesClass = hasLocalFeatures ? '' : 'hidden';
 - var noFeaturesClass = hasLocalFeatures ? 'hidden' : '';
-if hasFeatureset
-  h4 Featureset: #{featureset.name()}, version #{featureset.get('version')}
 
 div#isic-study-results-select-local-feature-container(class=hasFeaturesClass)
 

--- a/web_external/templates/widgets/studyResultsLocalFeaturesPage.jade
+++ b/web_external/templates/widgets/studyResultsLocalFeaturesPage.jade
@@ -1,12 +1,11 @@
 - var hasFeaturesClass = hasLocalFeatures ? '' : 'hidden';
 - var noFeaturesClass = hasLocalFeatures ? 'hidden' : '';
 
-div#isic-study-results-select-local-feature-container(class=hasFeaturesClass)
-
 .isic-study-results-local-features-content(class=noFeaturesClass)
   span N/A
 
 .isic-study-results-local-features-content(class=hasFeaturesClass)
+  #isic-study-results-select-local-feature-container
   .isic-study-results-local-features-legend
     .isic-study-results-local-features-legend-possible
       i &#9632;

--- a/web_external/templates/widgets/studyResultsLocalFeaturesPage.jade
+++ b/web_external/templates/widgets/studyResultsLocalFeaturesPage.jade
@@ -1,9 +1,7 @@
 - var hasFeaturesClass = hasLocalFeatures ? '' : 'hidden';
 - var noFeaturesClass = hasLocalFeatures ? 'hidden' : '';
 if hasFeatureset
-  h4 #{title} (#{featureset.name()}, version #{featureset.get('version')})
-else
-  h4 #{title}
+  h4 Featureset: #{featureset.name()}, version #{featureset.get('version')}
 
 div#isic-study-results-select-local-feature-container(class=hasFeaturesClass)
 

--- a/web_external/templates/widgets/studyResultsLocalFeaturesPage.jade
+++ b/web_external/templates/widgets/studyResultsLocalFeaturesPage.jade
@@ -18,5 +18,3 @@ div#isic-study-results-select-local-feature-container(class=hasFeaturesClass)
     .isic-study-results-local-features-legend-definite
       i &#9632;
       span  100% confidence
-  </div>
-  #isic-study-results-local-features-image-container

--- a/web_external/templates/widgets/studyResultsLocalFeaturesSelectPage.jade
+++ b/web_external/templates/widgets/studyResultsLocalFeaturesSelectPage.jade
@@ -1,4 +1,0 @@
-extends ./studyResultsSelectView.jade
-
-block modelOption
-  option(value=model.id, disabled=!featureAnnotated(model.id))= getName(model)

--- a/web_external/templates/widgets/studyResultsSelectImagePage.jade
+++ b/web_external/templates/widgets/studyResultsSelectImagePage.jade
@@ -1,0 +1,5 @@
+.isic-study-results-select-image-container
+  if models.length
+    each model in models
+      .isic-study-results-select-image-image-container(data-image-id=model.id)
+        = model.get('name')

--- a/web_external/templates/widgets/studyResultsSelectImagePage.jade
+++ b/web_external/templates/widgets/studyResultsSelectImagePage.jade
@@ -1,5 +1,4 @@
 .isic-study-results-select-image-container
-  if models.length
-    each model in models
-      .isic-study-results-select-image-image-container(data-image-id=model.id)
-        = model.get('name')
+  each model in models
+    .isic-study-results-select-image-image-container(data-image-id=model.id)
+      = model.get('name')

--- a/web_external/templates/widgets/studyResultsSelectImagePage.jade
+++ b/web_external/templates/widgets/studyResultsSelectImagePage.jade
@@ -1,4 +1,10 @@
+- var thumbnailSize = 30;
 .isic-study-results-select-image-container
   each model in models
     .isic-study-results-select-image-image-container(data-image-id=model.id)
-      = model.get('name')
+      span= model.get('name')
+      img(
+        src=apiRoot + '/image/' + model.id + '/thumbnail?width=' + thumbnailSize,
+        width=thumbnailSize,
+        height=thumbnailSize
+      )

--- a/web_external/templates/widgets/studyResultsSelectLocalFeaturesPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectLocalFeaturesPage.jade
@@ -1,5 +1,7 @@
 .isic-study-results-select-local-features-container
-  each model in models
-    if featureAnnotated(model.id)
-      span.isic-study-results-select-local-features-feature-container(data-feature-id=model.id)
-        = model.get('name')
+  // For select2, add width in style attribute, see https://select2.github.io/examples.html#responsive
+  select#isic-study-results-select-local-features-select.form-control.input(style='width:100%')
+    option(selected disabled value='')
+    each model in models
+      if featureAnnotated(model.id)
+        option(value=model.id)= model.get('name')

--- a/web_external/templates/widgets/studyResultsSelectLocalFeaturesPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectLocalFeaturesPage.jade
@@ -3,5 +3,4 @@
   select#isic-study-results-select-local-features-select.form-control.input(style='width:100%')
     option(selected disabled value='')
     each model in models
-      if featureAnnotated(model.id)
-        option(value=model.id)= model.get('name')
+      option(value=model.id)= model.get('name')

--- a/web_external/templates/widgets/studyResultsSelectLocalFeaturesPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectLocalFeaturesPage.jade
@@ -1,0 +1,5 @@
+.isic-study-results-select-local-features-container
+  each model in models
+    if featureAnnotated(model.id)
+      span.isic-study-results-select-local-features-feature-container(data-feature-id=model.id)
+        = model.get('name')

--- a/web_external/templates/widgets/studyResultsSelectStudyPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectStudyPage.jade
@@ -1,0 +1,7 @@
+.isic-study-results-select-study-container
+  label.control-label(for='isic-study-results-select-study-select') Study
+  select#isic-study-results-select-study-select.form-control.input.input-lg
+    option(selected disabled value='')
+      | Select...
+    each model in models
+      option(value=model.id)= model.get('name')

--- a/web_external/templates/widgets/studyResultsSelectStudyPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectStudyPage.jade
@@ -1,5 +1,5 @@
 .isic-study-results-select-study-container
-  label.control-label(for='isic-study-results-select-study-select') Study
+  label.control-label.isic-study-results-header(for='isic-study-results-select-study-select') Study
   select#isic-study-results-select-study-select.form-control.input.input-lg
     option(selected disabled value='')
       | Select...

--- a/web_external/templates/widgets/studyResultsSelectStudyPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectStudyPage.jade
@@ -1,4 +1,5 @@
 .isic-study-results-select-study-container
+  label.control-label.isic-study-results-header(for='isic-study-results-select-study-select') Study:
   select#isic-study-results-select-study-select.form-control.input
     option(selected disabled value='')
     each model in models

--- a/web_external/templates/widgets/studyResultsSelectStudyPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectStudyPage.jade
@@ -1,8 +1,6 @@
 .isic-study-results-select-study-container
-  label.control-label.isic-study-results-header(for='isic-study-results-select-study-select') Study:
   select#isic-study-results-select-study-select.form-control.input
     option(selected disabled value='')
-      | Select...
     each model in models
       option(value=model.id)= model.get('name')
   a.isic-study-results-select-study-details-button.btn.btn-default.isic-tooltip(

--- a/web_external/templates/widgets/studyResultsSelectStudyPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectStudyPage.jade
@@ -1,6 +1,6 @@
 .isic-study-results-select-study-container
   label.control-label.isic-study-results-header(for='isic-study-results-select-study-select') Study
-  select#isic-study-results-select-study-select.form-control.input.input-lg
+  select#isic-study-results-select-study-select.form-control.input
     option(selected disabled value='')
       | Select...
     each model in models

--- a/web_external/templates/widgets/studyResultsSelectStudyPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectStudyPage.jade
@@ -5,3 +5,6 @@
       | Select...
     each model in models
       option(value=model.id)= model.get('name')
+  a.isic-study-results-select-study-details-button.btn.btn-default.isic-tooltip(
+    title="View study details" disabled)
+    i.icon-list

--- a/web_external/templates/widgets/studyResultsSelectStudyPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectStudyPage.jade
@@ -1,5 +1,5 @@
 .isic-study-results-select-study-container
-  label.control-label.isic-study-results-header(for='isic-study-results-select-study-select') Study
+  label.control-label.isic-study-results-header(for='isic-study-results-select-study-select') Study:
   select#isic-study-results-select-study-select.form-control.input
     option(selected disabled value='')
       | Select...

--- a/web_external/templates/widgets/studyResultsSelectUsersPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectUsersPage.jade
@@ -1,0 +1,5 @@
+.isic-study-results-select-users-container
+  if models.length
+    each model in models
+      span.isic-study-results-select-users-user-container(data-user-id=model.id)
+        = getName(model)

--- a/web_external/templates/widgets/studyResultsSelectUsersPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectUsersPage.jade
@@ -1,4 +1,5 @@
 .isic-study-results-select-users-container
+  label.control-label.isic-study-results-header(for='isic-study-results-select-users-select') User:
   select#isic-study-results-select-users-select.form-control.input
     option(selected disabled value='')
     each model in models

--- a/web_external/templates/widgets/studyResultsSelectUsersPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectUsersPage.jade
@@ -1,5 +1,4 @@
 .isic-study-results-select-users-container
-  if models.length
-    each model in models
-      span.isic-study-results-select-users-user-container(data-user-id=model.id)
-        = getName(model)
+  each model in models
+    span.isic-study-results-select-users-user-container(data-user-id=model.id)
+      = getName(model)

--- a/web_external/templates/widgets/studyResultsSelectUsersPage.jade
+++ b/web_external/templates/widgets/studyResultsSelectUsersPage.jade
@@ -1,4 +1,5 @@
 .isic-study-results-select-users-container
-  each model in models
-    span.isic-study-results-select-users-user-container(data-user-id=model.id)
-      = getName(model)
+  select#isic-study-results-select-users-select.form-control.input
+    option(selected disabled value='')
+    each model in models
+      option(value=model.id)= getName(model)

--- a/web_external/templates/widgets/studyResultsSelectView.jade
+++ b/web_external/templates/widgets/studyResultsSelectView.jade
@@ -1,7 +1,0 @@
-label.control-label(for=selectId)= title
-select(id=selectId).form-control.input
-  option(selected disabled value='')
-    | Select...
-  each model in models
-    block modelOption
-      option(value=model.id)= getName(model)

--- a/web_external/templates/widgets/studyResultsStudyDetailPage.jade
+++ b/web_external/templates/widgets/studyResultsStudyDetailPage.jade
@@ -4,7 +4,7 @@
     - var featureset = model.get('featureset')
     table.table.table-condensed.isic-study-results-study-details-table
       tr
-        td Unique ID
+        td.isic-study-results-study-details-table-label Unique ID
         td
           code= model.id
       tr

--- a/web_external/templates/widgets/studyResultsStudyDetailPage.jade
+++ b/web_external/templates/widgets/studyResultsStudyDetailPage.jade
@@ -1,0 +1,11 @@
+.isic-study-results-study-details-container
+  .isic-study-results-header Study Details
+  if hasStudy
+    - var featureset = model.get('featureset')
+    table.table.table-condensed.isic-study-results-study-details-table
+      tr
+        td.isic-study-results-study-details-table-label Featureset
+        td #{featureset['name']} (version #{featureset['version']})
+      tr
+        td.isic-study-results-study-details-table-label Creator
+        td= formatUser(model.get('creator'))

--- a/web_external/templates/widgets/studyResultsStudyDetailPage.jade
+++ b/web_external/templates/widgets/studyResultsStudyDetailPage.jade
@@ -1,15 +1,25 @@
-.isic-study-results-study-details-container
-  .isic-study-results-header Study Details
-  if hasStudy
-    - var featureset = model.get('featureset')
-    table.table.table-condensed.isic-study-results-study-details-table
-      tr
-        td.isic-study-results-study-details-table-label Unique ID
-        td
-          code= model.id
-      tr
-        td.isic-study-results-study-details-table-label Featureset
-        td #{featureset['name']} (version #{featureset['version']})
-      tr
-        td.isic-study-results-study-details-table-label Creator
-        td= formatUser(model.get('creator'))
+.modal-dialog
+  .modal-content
+    .modal-header
+      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      h4.modal-title
+        | Study details
+      i.icon-eye
+      = model.get('name')
+    .modal-body
+      .isic-study-results-study-details-container
+        if hasStudy
+          - var featureset = model.get('featureset')
+          table.table.table-condensed.isic-study-results-study-details-table
+            tr
+              td.isic-study-results-study-details-table-label Unique ID
+              td
+                code= model.id
+            tr
+              td.isic-study-results-study-details-table-label Featureset
+              td #{featureset['name']} (version #{featureset['version']})
+            tr
+              td.isic-study-results-study-details-table-label Creator
+              td= formatUser(model.get('creator'))
+    .modal-footer
+      a.btn.btn-small.btn-primary(data-dismiss="modal") Close

--- a/web_external/templates/widgets/studyResultsStudyDetailPage.jade
+++ b/web_external/templates/widgets/studyResultsStudyDetailPage.jade
@@ -4,6 +4,10 @@
     - var featureset = model.get('featureset')
     table.table.table-condensed.isic-study-results-study-details-table
       tr
+        td Unique ID
+        td
+          code= model.id
+      tr
         td.isic-study-results-study-details-table-label Featureset
         td #{featureset['name']} (version #{featureset['version']})
       tr


### PR DESCRIPTION
TODO:
- [x] Spacing between sections
- [x] Make header appearance consistent; don't abuse 'label' for section headers
- [x] Dropdowns shouldn't fill width
- [x] Global feature table shouldn't expand to fill width
- [x] New user selection interface
- [x] Add study details
- [x] Add image count
- [x] Add image thumbnails
- [x] Fit more information on screen (reduce whitespace, possibly move study selection to a separate mode or page, reduce font sizes, etc.)
- [ ] Make layout/interaction more intuitive
- [x] Display image on "Image Preview" tab instead of "Global Features"
- [x] Hide feature tabs until user selects an image

Possible future work:
- [ ] Allow selecting multiple users (requires server support)
- [ ] Allow selecting multiple local features (requires server support)
- [ ] Add image metadata (i.e. number of annotations, raters)
- [ ] Loading indicators
- [ ] Add button to add users to study (move from Manage Annotation Studies)
- [ ] Add button to create new study (move from Manage Annotation Studies)
