### PR TITLE
Use non-breaking spaces to format image counts correctly

### DIFF
--- a/web_external/templates/body/imagesPage.jade
+++ b/web_external/templates/body/imagesPage.jade
@@ -16,27 +16,27 @@
           #isic-images-seekLast.button
             img(data-name='seekLast')
           #isic-images-noPagingOrFilters.detailLabel
-            | Showing all
+            | Showing all&nbsp;
             span.page 10
             |  images in the archive.
           #isic-images-hasPaging.detailLabel
-            | Showing images
+            | Showing images&nbsp;
             span.page 0 - 10
-            |  of
+            |  of&nbsp;
             span.filteredSet 100
             |  total images.
           #isic-images-hasFilters.detailLabel
-            | Showing
+            | Showing&nbsp;
             span.filteredSet 100
-            |  of the
+            |  of the&nbsp;
             span.overview 1000
             |  total number of images in the archive.
           #isic-images-hasFiltersAndPaging.detailLabel
-            | Showing images
+            | Showing images&nbsp;
             span.page 0 - 10
-            |  of
+            |  of&nbsp;
             span.filteredSet 100
-            |  filtered images. There are
+            |  filtered images. There are&nbsp;
             span.overview 1000
             |  total images in the archive (ignoring filters).
         #isic-images-pagingBars.flexRow


### PR DESCRIPTION
Closes #165 