### PR TITLE
Ignore entire .vagrant directory (not just its contents)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ var/
 .idea/*
 
 # Vagrant
-.vagrant/*
+.vagrant
 
 # Vim
 *.swp


### PR DESCRIPTION
This lets `git clean -dfn` et al. work properly.