### PR TITLE
Use a lightbox to display image detail

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,8 +126,6 @@ module.exports = function (grunt) {
                 'jquery/dist/jquery.min.js',
                 'flatstrap/dist/js/bootstrap.min.js',
                 'flatstrap/dist/css/bootstrap.min.css',
-                'flatstrap/dist/fonts/glyphicons-halflings-regular.woff',
-                'flatstrap/dist/fonts/glyphicons-halflings-regular.ttf',
                 'font-awesome/css/font-awesome.min.css',
                 'angular/angular.min.js',
                 'angular-resource/angular-resource.min.js',
@@ -140,6 +138,16 @@ module.exports = function (grunt) {
         });
         defaultTasks.push('copy:' + pluginName + '_bower_libs');
 
+        grunt.config.set('copy.' + pluginName + '_font_files', {
+            expand: true,
+            cwd: pluginDir + '/bower_components/flatstrap/dist/fonts',
+            src: [
+                'glyphicons-halflings-regular.woff',
+                'glyphicons-halflings-regular.ttf'
+            ],
+            dest: 'clients/web/static/fonts'
+        });
+        defaultTasks.push('copy:' + pluginName + '_font_files');
     };
 
     configureIsicArchive();

--- a/web_external/js/views/body/FeaturesetsView.js
+++ b/web_external/js/views/body/FeaturesetsView.js
@@ -5,7 +5,7 @@ isic.views.FeaturesetsView = isic.View.extend({
             var target = $(event.target);
             target.parent().find('.icon-right-open').removeClass('icon-right-open').addClass('icon-down-open');
 
-            var viewIndex = window.parseInt(target.attr('data-model-index'), 10);
+            var viewIndex = parseInt(target.attr('data-model-index'), 10);
             var viewContainer = target.find('.isic-listing-panel-body');
             this.renderFeatureset(viewIndex, viewContainer);
         },

--- a/web_external/js/views/body/ImagesView/HistogramPane.js
+++ b/web_external/js/views/body/ImagesView/HistogramPane.js
@@ -40,7 +40,7 @@ isic.views.ImagesViewSubViews.HistogramPane = Backbone.View.extend({
         var attributeSectionsEnter = attributeSections.enter().append('div');
         attributeSections.exit()
             .each(_.bind(function (d) {
-                var histogramId = window.shims.makeValidId(d + '_histogramContent');
+                var histogramId = isic.shims.makeValidId(d + '_histogramContent');
                 delete this.individualHistograms[histogramId];
             }, this)).remove();
         attributeSections.attr('class', 'attributeSection');
@@ -83,9 +83,9 @@ isic.views.ImagesViewSubViews.HistogramPane = Backbone.View.extend({
         sectionTitlesEnter.append('span');
         sectionTitles.select('span')
             .text(function (d) {
-                if (window.ENUMS.SCHEMA[d] &&
-                        window.ENUMS.SCHEMA[d].humanName) {
-                    return window.ENUMS.SCHEMA[d].humanName;
+                if (isic.ENUMS.SCHEMA[d] &&
+                        isic.ENUMS.SCHEMA[d].humanName) {
+                    return isic.ENUMS.SCHEMA[d].humanName;
                 } else {
                     return d;
                 }
@@ -96,11 +96,11 @@ isic.views.ImagesViewSubViews.HistogramPane = Backbone.View.extend({
         attributeSectionsEnter.append('svg')
             .attr('class', 'collapsed content')
             .attr('id', function (d) {
-                return window.shims.makeValidId(d + '_histogramContent');
+                return isic.shims.makeValidId(d + '_histogramContent');
             })
             .each(function (d) {
                 // this refers to the DOM element
-                var histogramId = window.shims.makeValidId(d + '_histogramContent');
+                var histogramId = isic.shims.makeValidId(d + '_histogramContent');
                 self.individualHistograms[histogramId] =
                     new isic.views.ImagesViewSubViews.IndividualHistogram({
                         el: this,
@@ -109,7 +109,7 @@ isic.views.ImagesViewSubViews.HistogramPane = Backbone.View.extend({
                     });
             });
         attributeSections.select('.content').each(_.bind(function (d) {
-            var histogramId = window.shims.makeValidId(d + '_histogramContent');
+            var histogramId = isic.shims.makeValidId(d + '_histogramContent');
             this.individualHistograms[histogramId].render();
         }, this));
         return this;

--- a/web_external/js/views/body/ImagesView/HistogramScale.js
+++ b/web_external/js/views/body/ImagesView/HistogramScale.js
@@ -47,7 +47,7 @@
         // the first categorical value? While we're at it, determine the
         // real max vertical count, and construct bin lookup tables for
         // each histogram.
-        this.overviewHistogram.forEach(_.bind(function (bin, index) {
+        _.each(this.overviewHistogram, function (bin, index) {
             if (bin.hasOwnProperty('lowBound') && bin.hasOwnProperty('highBound')) {
                 this.ordinalBinCount += 1;
                 if (this.lowBound === undefined || bin.lowBound < this.lowBound) {
@@ -66,13 +66,13 @@
             }
             this.overviewLabelLookup[bin.label] = index;
             this.realYmax = Math.max(this.realYmax, bin.count);
-        }, this));
-        this.filteredSetHistogram.forEach(_.bind(function (bin, index) {
+        }, this);
+        _.each(this.filteredSetHistogram, function (bin, index) {
             this.filteredLabelLookup[bin.label] = index;
-        }, this));
-        this.pageHistogram.forEach(_.bind(function (bin, index) {
+        }, this);
+        _.each(this.pageHistogram, function (bin, index) {
             this.pageLabelLookup[bin.label] = index;
-        }, this));
+        }, this);
 
         // If the new data is shorter than the previous custom
         // customYmax, just clear the custom customYmax

--- a/web_external/js/views/body/ImagesView/HistogramScale.js
+++ b/web_external/js/views/body/ImagesView/HistogramScale.js
@@ -48,7 +48,7 @@
         // real max vertical count, and construct bin lookup tables for
         // each histogram.
         _.each(this.overviewHistogram, function (bin, index) {
-            if (bin.hasOwnProperty('lowBound') && bin.hasOwnProperty('highBound')) {
+            if (_.has(bin, 'lowBound') && _.has(bin, 'highBound')) {
                 this.ordinalBinCount += 1;
                 if (this.lowBound === undefined || bin.lowBound < this.lowBound) {
                     this.lowBound = bin.lowBound;

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -4,6 +4,7 @@ isic.views.ImagesViewSubViews = isic.views.ImagesViewSubViews || {};
 isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
     events: {
         'click .button': 'clearSelectedImage',
+        'click .openwindow': 'openwindow',
         'click .fullscreen': 'fullscreen'
     },
 
@@ -65,7 +66,7 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
         return this;
     },
 
-    fullscreen: function () {
+    openwindow: function () {
       window.open('/api/v1/image/' + this.image.id + '/download?contentDisposition=inline');
     },
 

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -65,16 +65,21 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
             this.$('#isic-image-details-segmentations-display-view-container')).render();
 
         // Initialize Bootstrap tooltips.
-        this.$('[data-toggle="tooltip"]').tooltip();
+        this.$('[data-toggle="tooltip"]').tooltip({
+            trigger: 'hover'
+        });
 
         return this;
     },
 
     openwindow: function () {
+      $('[data-toggle="tooltip"]').tooltip('hide');
       window.open('/api/v1/image/' + this.image.id + '/download?contentDisposition=inline');
     },
 
     fullscreen: function () {
+      $('[data-toggle="tooltip"]').tooltip('hide');
+
       var img = $('.focusimage');
       var modal = $('#focusmodal');
 

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -3,7 +3,8 @@ isic.views.ImagesViewSubViews = isic.views.ImagesViewSubViews || {};
 // View for image details
 isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
     events: {
-        'click .button': 'clearSelectedImage'
+        'click .button': 'clearSelectedImage',
+        'click .fullscreen': 'fullscreen'
     },
 
     initialize: function (settings) {
@@ -62,6 +63,10 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
             this.$('#isic-image-details-segmentations-display-view-container')).render();
 
         return this;
+    },
+
+    fullscreen: function () {
+      console.log('fullscreen');
     },
 
     clearSelectedImage: function () {

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -64,21 +64,18 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
         this.segmentationsDisplayView.setElement(
             this.$('#isic-image-details-segmentations-display-view-container')).render();
 
-        // Initialize Bootstrap tooltips.
-        this.$('[data-toggle="tooltip"]').tooltip({
-            trigger: 'hover'
-        });
+        this.initializeTooltips();
 
         return this;
     },
 
     openwindow: function () {
-      $('[data-toggle="tooltip"]').tooltip('hide');
+      this.clearTooltips();
       window.open('/api/v1/image/' + this.image.id + '/download?contentDisposition=inline');
     },
 
     fullscreen: function () {
-      $('[data-toggle="tooltip"]').tooltip('hide');
+      this.clearTooltips();
 
       var img = $('.focusimage');
       var modal = $('#focusmodal');
@@ -122,5 +119,15 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
 
     clearSelectedImage: function () {
         this.image.clear();
+    },
+
+    initializeTooltips: function () {
+        this.$('[data-toggle="tooltip"]').tooltip({
+            trigger: 'hover'
+        });
+    },
+
+    clearTooltips: function () {
+      $('[data-toggle="tooltip"]').tooltip('hide');
     }
 });

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -70,6 +70,42 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
       window.open('/api/v1/image/' + this.image.id + '/download?contentDisposition=inline');
     },
 
+    fullscreen: function () {
+      var img = $('.focusimage');
+      var modal = $('#focusmodal');
+
+      // Supply the image element with a new src attribute to display the image.
+      var src = '/api/v1/image/' + this.image.id + '/download?contentDisposition=inline';
+      img.attr('src', src);
+
+      // Create a dummy image element so we can learn the size of the new image.
+      // When the image is loaded, we can use its size to properly resize and
+      // situate the modal.
+      var image = new Image();
+      image.onload = function () {
+        // Add thirty to represent the 15px padding that comes stock with a
+        // Bootstrap modal.
+        var modalWidth = image.width + 30;
+        var modalHeight = image.height + 30;
+
+        // Set the CSS of the dialog so it appears vertically and horizontally
+        // centered in the webpage (even with browser resizing).
+        modal.find('.modal-dialog').css({
+          width: modalWidth + 'px',
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          'margin-top': (-modalHeight / 2) + 'px',
+          'margin-left': (-modalWidth / 2) + 'px'
+        });
+
+        // Now that the image and CSS are ready, show the modal.
+        modal.modal('show');
+      };
+
+      image.src = src;
+    },
+
     clearSelectedImage: function () {
         this.image.clear();
     }

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -103,6 +103,11 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
         modal.modal('show');
       };
 
+      // Allow clicking on the image itself to dismiss the modal.
+      img.on('click.dismiss', function () {
+        $('#focusmodal').modal('hide');
+      });
+
       image.src = src;
     },
 

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -17,6 +17,7 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
             image: this.image,
             parentView: this
         });
+
     },
 
     render: function () {
@@ -62,6 +63,9 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
 
         this.segmentationsDisplayView.setElement(
             this.$('#isic-image-details-segmentations-display-view-container')).render();
+
+        // Initialize Bootstrap tooltips.
+        this.$('[data-toggle="tooltip"]').tooltip();
 
         return this;
     },

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -66,7 +66,7 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
     },
 
     fullscreen: function () {
-      console.log('fullscreen');
+      window.open('/api/v1/image/' + this.image.id + '/download?contentDisposition=inline');
     },
 
     clearSelectedImage: function () {

--- a/web_external/js/views/body/ImagesView/ImageWall.js
+++ b/web_external/js/views/body/ImagesView/ImageWall.js
@@ -257,43 +257,6 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
                 return d;
             });
 
-        // This click callback has to be defined here with a name because it
-        // must refer to itself.
-        var self = this;
-        var click = function (d) {
-            // Capture the target element for reference in the nested callback.
-            var that = this;
-
-            // This flag and nested callback will detect whether a second click
-            // arrives.
-            var doubleclick;
-            d3.select(that).on('click.second', function () {
-                doubleclick = true;
-            });
-
-            // This temporarily removes the outer callback from firing (since we
-            // don't want to wreck the careful state we're cultivating waiting
-            // for a possible second click).
-            d3.select(that).on('click', null);
-
-            // Allow 300 ms for a second click to be detected.
-            setTimeout(function () {
-                // When the 300 ms is up, remove the detector callback and
-                // reinstate the main click handler.
-                d3.select(that).on('click.second', null);
-                d3.select(that).on('click', click);
-
-                // If a double click was detected, then open the full size image
-                // in a new window; otherwise, toggle the selection state of the
-                // image.
-                if (doubleclick) {
-                    window.open('/api/v1/image/' + d + '/download?contentDisposition=inline');
-                } else {
-                    self.selectImage(d === self.image.id ? null : d);
-                }
-            }, 300);
-        };
-
         images.enter().append('image')
             .attr('preserveAspectRatio', 'xMinYMin');
         images.exit().remove();
@@ -318,7 +281,9 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
             y: function (d) {
                 return placementLookup[d].y;
             }
-        }).on('click', click);
+        }).on('click', _.bind(function (d) {
+            this.selectImage(d === this.image.id ? null : d)
+        }, this));
 
         // Draw the highlight rect
         var selectedImageId = this.image.id;

--- a/web_external/js/views/body/ImagesView/ImageWall.js
+++ b/web_external/js/views/body/ImagesView/ImageWall.js
@@ -23,7 +23,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
         // Start fetching the images now... don't wait
         // around for the call in render()
         _.each(this.model.get('imageIds'), function (i) {
-            if (!this.imageCache.hasOwnProperty(i)) {
+            if (!_.has(this.imageCache, i)) {
                 this.imageCache[i] = new Image();
                 this.imageCache[i].addEventListener('load', _.bind(function () {
                     if (!this.imageCache[i].width || !this.imageCache[i].height) {
@@ -89,7 +89,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
         var imagesToPlace = [];
 
         _.each(Object.keys(this.loadedImages), function (imageId) {
-            if (!this.imageColumnLookup.hasOwnProperty(imageId)) {
+            if (!_.has(this.imageColumnLookup, imageId)) {
                 // For some reason, browsers seem to be
                 // loading the images backwards. For a
                 // better top-down effect (especially
@@ -250,7 +250,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
         // Okay, time to draw the pictures (in their initial positions)
         var imageList = Object.keys(this.loadedImages)
             .filter(function (d) {
-                return placementLookup.hasOwnProperty(d);
+                return _.has(placementLookup, d);
             });
         var images = svg.select('#previewContents').selectAll('image')
             .data(imageList, function (d) {

--- a/web_external/js/views/body/ImagesView/ImageWall.js
+++ b/web_external/js/views/body/ImagesView/ImageWall.js
@@ -49,8 +49,8 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
 
         // Clear out any old IDs after a while (don't do it immediately in case
         // the user is flipping back and forth between pages)
-        window.clearTimeout(this.cleanupTimeout);
-        this.cleanupTimeout = window.setTimeout(_.bind(function () {
+        clearTimeout(this.cleanupTimeout);
+        this.cleanupTimeout = setTimeout(_.bind(function () {
             _.each(Object.keys(this.imageCache), function (i) {
                 if (this.model.get('imageIds').indexOf(i) === -1) {
                     delete this.imageCache[i];

--- a/web_external/js/views/body/ImagesView/ImageWall.js
+++ b/web_external/js/views/body/ImagesView/ImageWall.js
@@ -22,7 +22,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
 
         // Start fetching the images now... don't wait
         // around for the call in render()
-        this.model.get('imageIds').forEach(_.bind(function (i) {
+        _.each(this.model.get('imageIds'), function (i) {
             if (!this.imageCache.hasOwnProperty(i)) {
                 this.imageCache[i] = new Image();
                 this.imageCache[i].addEventListener('load', _.bind(function () {
@@ -45,18 +45,18 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
                 this.loadedImages[i] = true;
                 this.render();
             }
-        }, this));
+        }, this);
 
         // Clear out any old IDs after a while (don't do it immediately in case
         // the user is flipping back and forth between pages)
         window.clearTimeout(this.cleanupTimeout);
         this.cleanupTimeout = window.setTimeout(_.bind(function () {
-            Object.keys(this.imageCache).forEach(_.bind(function (i) {
+            _.each(Object.keys(this.imageCache), function (i) {
                 if (this.model.get('imageIds').indexOf(i) === -1) {
                     delete this.imageCache[i];
                     delete this.loadedImages[i];
                 }
-            }, this));
+            }, this);
         }, this), 10000);
     },
     handleBadImage: function (imageId) {
@@ -75,7 +75,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
          */
 
         // Remove any images that aren't here any more
-        Object.keys(this.imageColumnLookup).forEach(_.bind(function (imageId) {
+        _.each(Object.keys(this.imageColumnLookup), function (imageId) {
             if (this.model.get('imageIds').indexOf(imageId) === -1) {
                 myColumn = this.imageColumnLookup[imageId];
                 myIndex = this.imageColumns[myColumn].indexOf(imageId);
@@ -83,12 +83,12 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
                 this.imageColumns[myColumn].splice(myIndex, 1);
                 delete this.imageColumnLookup[imageId];
             }
-        }, this));
+        }, this);
 
         // Figure out which new images need placing
         var imagesToPlace = [];
 
-        Object.keys(this.loadedImages).forEach(_.bind(function (imageId) {
+        _.each(Object.keys(this.loadedImages), function (imageId) {
             if (!this.imageColumnLookup.hasOwnProperty(imageId)) {
                 // For some reason, browsers seem to be
                 // loading the images backwards. For a
@@ -97,7 +97,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
                 // inserting them at the beginning
                 imagesToPlace.splice(0, 0, imageId);
             }
-        }, this));
+        }, this);
 
         // Add or remove columns as necessary (images in
         // a dying column need to be placed again)
@@ -107,10 +107,10 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
         while (this.imageColumns.length > numColumns) {
             var dyingColumn = this.imageColumns.pop();
             if (dyingColumn) {
-                dyingColumn.forEach(_.bind(function (imageId) {
+                _.each(dyingColumn, function (imageId) {
                     delete this.imageColumnLookup[imageId];
                     imagesToPlace.push(imageId);
-                }, this));
+                }, this);
             }
         }
 
@@ -126,7 +126,7 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
                 maxLength: 0
             };
 
-            this.imageColumns.forEach(function (column, index) {
+            _.each(this.imageColumns, function (column, index) {
                 if (column.length > result.maxLength) {
                     result.maxLength = column.length;
                     result.maxIndices = [index];
@@ -221,9 +221,9 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
         var placementLookup = {};
         var tallestHeight = 0;
         var availableImages = 0;
-        this.imageColumns.forEach(_.bind(function (column, index) {
+        _.each(this.imageColumns, function (column, index) {
             var y = imagePadding;
-            column.forEach(_.bind(function (imageId) {
+            _.each(column, function (imageId) {
                 // Calculate the natural height of the image
                 var height;
                 availableImages += 1;
@@ -235,11 +235,11 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
                     height: height
                 };
                 y += height + imagePadding;
-            }, this));
+            }, this);
             if (y > tallestHeight) {
                 tallestHeight = y;
             }
-        }, this));
+        }, this);
 
         // After all that, we finally know how much space we need
         svg.attr({

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -174,10 +174,10 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
     },
     autoDetectAttributeInterpretation: function (attrName) {
         // Go with the default interpretation for the attribute type
-        return window.ENUMS.DEFAULT_INTERPRETATIONS[this.getAttributeType(attrName)];
+        return isic.ENUMS.DEFAULT_INTERPRETATIONS[this.getAttributeType(attrName)];
     },
     getAttributeInterpretation: function (attrName) {
-        var attrSpec = window.ENUMS.SCHEMA[attrName];
+        var attrSpec = isic.ENUMS.SCHEMA[attrName];
         if (attrSpec.interpretation) {
             // The user has specified an interpretation
             return attrSpec.interpretation;
@@ -187,11 +187,11 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         }
     },
     autoDetectAttributeType: function (attrName) {
-        var attrSpec = window.ENUMS.SCHEMA[attrName];
+        var attrSpec = isic.ENUMS.SCHEMA[attrName];
         // Find the most specific type that can accomodate all the values
         var attrType = 'object';
         var count = 0;
-        _.each(window.ENUMS.ATTRIBUTE_GENERALITY, function (dataType) {
+        _.each(isic.ENUMS.ATTRIBUTE_GENERALITY, function (dataType) {
             if (_.has(attrSpec, dataType) &&
                   attrSpec[dataType].count >= count) {
                 attrType = dataType;
@@ -201,7 +201,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         return attrType;
     },
     getAttributeType: function (attrName) {
-        var attrSpec = window.ENUMS.SCHEMA[attrName];
+        var attrSpec = isic.ENUMS.SCHEMA[attrName];
         if (attrSpec.coerceToType) {
             // The user has specified a data type
             return attrSpec.coerceToType;
@@ -214,8 +214,8 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         // Easy check (that also validates whether filter.standard[attrName]
         // even exists)
         var filterState = this.getFilteredState(attrName);
-        if (filterState === window.ENUMS.FILTER_STATES.NO_FILTERS) {
-            return window.ENUMS.BIN_STATES.INCLUDED;
+        if (filterState === isic.ENUMS.FILTER_STATES.NO_FILTERS) {
+            return isic.ENUMS.BIN_STATES.INCLUDED;
         }
 
         var filterSpec = this.get('filter').standard[attrName];
@@ -224,10 +224,10 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         // one) / in the list that is specifically excluded?
         if (filterSpec.includeValues &&
                 filterSpec.includeValues.indexOf(bin.label) === -1) {
-            return window.ENUMS.BIN_STATES.EXCLUDED;
+            return isic.ENUMS.BIN_STATES.EXCLUDED;
         } else if (filterSpec.excludeValues &&
                 filterSpec.excludeValues.indexOf(bin.label) !== -1) {
-            return window.ENUMS.BIN_STATES.EXCLUDED;
+            return isic.ENUMS.BIN_STATES.EXCLUDED;
         }
 
         // Trickiest check: is the range excluded (or partially excluded)?
@@ -242,7 +242,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
                 };
             }
             // Intersect the bin with the excluded values
-            var includedRanges = window.shims.RangeSet.rangeSubtract([{
+            var includedRanges = isic.shims.RangeSet.rangeSubtract([{
                 lowBound: bin.lowBound,
                 highBound: bin.highBound
             }], filterSpec.excludeRanges, comparator);
@@ -252,19 +252,19 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
                     includedRanges[0].highBound === bin.highBound) {
                 // Wound up with the same range we started with;
                 // the whole bin is included
-                return window.ENUMS.BIN_STATES.INCLUDED;
+                return isic.ENUMS.BIN_STATES.INCLUDED;
             } else if (includedRanges.length > 0) {
                 // Only a piece survived; this is a partial!
-                return window.ENUMS.BIN_STATES.PARTIAL;
+                return isic.ENUMS.BIN_STATES.PARTIAL;
             } else {
                 // Nothing survived the subtraction; this bin
                 // is excluded
-                return window.ENUMS.BIN_STATES.EXCLUDED;
+                return isic.ENUMS.BIN_STATES.EXCLUDED;
             }
         }
 
         // No filter info left to check; the bin must be included
-        return window.ENUMS.BIN_STATES.INCLUDED;
+        return isic.ENUMS.BIN_STATES.INCLUDED;
     },
     applyFilter: function (filter) {
         // Clean up the filter specification
@@ -335,7 +335,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         if (highBound !== undefined) {
             range.highBound = highBound;
         }
-        excludeRanges = window.shims.RangeSet.rangeUnion(
+        excludeRanges = isic.shims.RangeSet.rangeUnion(
             excludeRanges, [range], comparator);
         filter.standard[attrName].excludeRanges = excludeRanges;
 
@@ -357,7 +357,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         if (highBound !== undefined) {
             range.highBound = highBound;
         }
-        excludeRanges = window.shims.RangeSet.rangeSubtract(
+        excludeRanges = isic.shims.RangeSet.rangeSubtract(
             excludeRanges, [range], comparator);
         filter.standard[attrName].excludeRanges = excludeRanges;
 
@@ -417,12 +417,12 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         var filter = this.get('filter');
         if (filter.standard[attrName]) {
             if (filter.standard[attrName].excludeAttribute) {
-                return window.ENUMS.FILTER_STATES.EXCLUDED;
+                return isic.ENUMS.FILTER_STATES.EXCLUDED;
             } else {
-                return window.ENUMS.FILTER_STATES.FILTERED;
+                return isic.ENUMS.FILTER_STATES.FILTERED;
             }
         } else {
-            return window.ENUMS.FILTER_STATES.NO_FILTERS;
+            return isic.ENUMS.FILTER_STATES.NO_FILTERS;
         }
     },
     listCategoricalFilterExpressions: function (attrName, filterSpec, hexify) {

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -192,7 +192,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         var attrType = 'object';
         var count = 0;
         _.each(window.ENUMS.ATTRIBUTE_GENERALITY, function (dataType) {
-            if (attrSpec.hasOwnProperty(dataType) &&
+            if (_.has(attrSpec, dataType) &&
                   attrSpec[dataType].count >= count) {
                 attrType = dataType;
                 count = attrSpec[dataType].count;
@@ -232,8 +232,8 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
 
         // Trickiest check: is the range excluded (or partially excluded)?
         if (filterSpec.excludeRanges &&
-                bin.hasOwnProperty('lowBound') &&
-                bin.hasOwnProperty('highBound')) {
+                _.has(bin, 'lowBound') &&
+                _.has(bin, 'highBound')) {
             // Make sure to use proper string comparisons if this is a string bin
             var comparator;
             if (this.getAttributeType(attrName) === 'string') {
@@ -270,9 +270,9 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         // Clean up the filter specification
         var standardKeys = Object.keys(filter.standard);
         _.each(standardKeys, function (k) {
-            var removeFilterSpec = !(filter.standard[k].hasOwnProperty('excludeAttribute'));
+            var removeFilterSpec = !_.has(filter.standard[k], 'excludeAttribute');
             _.each(['excludeRanges', 'includeValues', 'excludeValues'], function (d) {
-                if (filter.standard[k].hasOwnProperty(d)) {
+                if (_.has(filter.standard[k], d)) {
                     if (filter.standard[k][d].length === 0) {
                         delete filter.standard[k][d];
                     } else {
@@ -295,7 +295,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
     },
     clearFilters: function (attrName) {
         var filter = this.get('filter');
-        if (filter.standard.hasOwnProperty(attrName)) {
+        if (_.has(filter.standard, attrName)) {
             delete filter.standard[attrName].excludeRanges;
             delete filter.standard[attrName].excludeValues;
             delete filter.standard[attrName].includeValues;
@@ -429,10 +429,10 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         hexify = !!hexify;
         var values;
         var operation;
-        if (filterSpec.hasOwnProperty('includeValues')) {
+        if (_.has(filterSpec, 'includeValues')) {
             values = filterSpec.includeValues;
             operation = ' in ';
-        } else if (filterSpec.hasOwnProperty('excludeValues')) {
+        } else if (_.has(filterSpec, 'excludeValues')) {
             values = filterSpec.excludeValues;
             operation = ' not in ';
         } else {
@@ -469,7 +469,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
                 temp += '(';
                 var includeLow = false;
                 var dataType;
-                if (range.hasOwnProperty('lowBound')) {
+                if (_.has(range, 'lowBound')) {
                     var lowBound = range.lowBound;
                     dataType = typeof lowBound;
                     if (dataType === 'string' || dataType === 'object') {
@@ -481,7 +481,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
                     temp += attrName + ' < ' + lowBound;
                     includeLow = true;
                 }
-                if (range.hasOwnProperty('highBound')) {
+                if (_.has(range, 'highBound')) {
                     if (includeLow) {
                         temp += ' or ';
                     }

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -191,7 +191,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         // Find the most specific type that can accomodate all the values
         var attrType = 'object';
         var count = 0;
-        window.ENUMS.ATTRIBUTE_GENERALITY.forEach(function (dataType) {
+        _.each(window.ENUMS.ATTRIBUTE_GENERALITY, function (dataType) {
             if (attrSpec.hasOwnProperty(dataType) &&
                   attrSpec[dataType].count >= count) {
                 attrType = dataType;
@@ -269,9 +269,9 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
     applyFilter: function (filter) {
         // Clean up the filter specification
         var standardKeys = Object.keys(filter.standard);
-        standardKeys.forEach(function (k) {
+        _.each(standardKeys, function (k) {
             var removeFilterSpec = !(filter.standard[k].hasOwnProperty('excludeAttribute'));
-            ['excludeRanges', 'includeValues', 'excludeValues'].forEach(function (d) {
+            _.each(['excludeRanges', 'includeValues', 'excludeValues'], function (d) {
                 if (filter.standard[k].hasOwnProperty(d)) {
                     if (filter.standard[k][d].length === 0) {
                         delete filter.standard[k][d];
@@ -442,13 +442,13 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
             attrName = this.stringToHex(attrName);
             var temp = values;
             values = [];
-            temp.forEach(_.bind(function (value) {
+            _.each(temp, function (value) {
                 var dataType = typeof value;
                 if (dataType === 'string' || dataType === 'object') {
                     value = this.stringToHex(value);
                 }
                 values.push(value);
-            }, this));
+            }, this);
         }
         return [attrName + operation + JSON.stringify(values)];
     },
@@ -461,7 +461,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
             if (hexify) {
                 attrName = this.stringToHex(attrName);
             }
-            filterSpec.excludeRanges.forEach(_.bind(function (range) {
+            _.each(filterSpec.excludeRanges, function (range) {
                 if (!firstRange) {
                     temp += ' and ';
                 }
@@ -496,7 +496,7 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
                     temp += attrName + ' >= ' + highBound;
                 }
                 temp += ')';
-            }, this));
+            }, this);
             temp += ')';
             results.push(temp);
         }
@@ -506,11 +506,11 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         hexify = !!hexify;
         var filter = this.get('filter');
         var results = [];
-        Object.keys(filter.standard).forEach(_.bind(function (attrName) {
+        _.each(Object.keys(filter.standard), function (attrName) {
             var filterSpec = filter.standard[attrName];
             results = results.concat(this.listCategoricalFilterExpressions(attrName, filterSpec, hexify));
             results = results.concat(this.listRangeFilterExpressions(attrName, filterSpec, hexify));
-        }, this));
+        }, this);
         return results;
     },
     listAllFilterExpressions: function (hexify) {
@@ -533,13 +533,13 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         }
         if (_.isObject(obj)) {
             if (_.isArray(obj)) {
-                obj.forEach(_.bind(function (d, i) {
+                _.each(obj, function (d, i) {
                     obj[i] = this.dehexify(d);
-                }, this));
+                }, this);
             } else {
-                Object.keys(obj).forEach(_.bind(function (k) {
+                _.each(Object.keys(obj), function (k) {
                     obj[k] = this.dehexify(obj[k]);
-                }, this));
+                }, this);
             }
         } else if (_.isString(obj)) {
             obj = decodeURIComponent(obj);
@@ -557,13 +557,13 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
                 obj.type = attrType;
             }
         } else if (_.isArray(obj)) {
-            obj.forEach(_.bind(function (d, i) {
+            _.each(obj, function (d, i) {
                 obj[i] = this.specifyAttrTypes(d);
-            }, this));
+            }, this);
         } else {
-            Object.keys(obj).forEach(_.bind(function (k) {
+            _.each(Object.keys(obj), function (k) {
                 obj[k] = this.specifyAttrTypes(obj[k]);
-            }, this));
+            }, this);
         }
         return obj;
     },

--- a/web_external/js/views/body/ImagesView/index.js
+++ b/web_external/js/views/body/ImagesView/index.js
@@ -54,7 +54,7 @@ isic.views.ImagesView = isic.View.extend({
             this.$el.html(isic.templates.imagesPage({
                 staticRoot: girder.staticRoot
             }));
-            window.shims.recolorImageFilters(['#00ABFF', '#444499', '#CCCCCC']);
+            isic.shims.recolorImageFilters(['#00ABFF', '#444499', '#CCCCCC']);
             this.datasetPane.setElement(this.$('#isic-images-datasetPane'));
             this.histogramPane.setElement(this.$('#isic-images-histogramPane'));
             this.imageWall.setElement(this.$('#isic-images-imageWall'));

--- a/web_external/js/views/body/ImagesView/shims/enums.js
+++ b/web_external/js/views/body/ImagesView/shims/enums.js
@@ -1,8 +1,8 @@
 // TODO: there's probably a better way to import these...
 
-window.ENUMS = {};
+isic.ENUMS = {};
 
-window.ENUMS.DEFAULT_INTERPRETATIONS = {
+isic.ENUMS.DEFAULT_INTERPRETATIONS = {
     'undefined': 'categorical',
     'null': 'categorical',
     boolean: 'categorical',
@@ -13,20 +13,20 @@ window.ENUMS.DEFAULT_INTERPRETATIONS = {
     object: 'categorical'
 };
 
-window.ENUMS.ATTRIBUTE_GENERALITY = [
+isic.ENUMS.ATTRIBUTE_GENERALITY = [
     'object',
     'string',
     'number',
     'integer'
 ];
 
-window.ENUMS.FILTER_STATES = {
+isic.ENUMS.FILTER_STATES = {
     NO_FILTERS: 0,
     FILTERED: 1,
     EXCLUDED: 2
 };
 
-window.ENUMS.BIN_STATES = {
+isic.ENUMS.BIN_STATES = {
     INCLUDED: 0,
     EXCLUDED: 1,
     PARTIAL: 2
@@ -34,7 +34,7 @@ window.ENUMS.BIN_STATES = {
 
 // TODO: It should be trivial to borrow code from Resonant Laboratory to
 // autodetect this (requires an additional server endpoint)
-window.ENUMS.SCHEMA = {
+isic.ENUMS.SCHEMA = {
     'folderId': {
         'coerceToType': 'string',
         'humanName': 'Dataset'

--- a/web_external/js/views/body/ImagesView/shims/makeValidId.js
+++ b/web_external/js/views/body/ImagesView/shims/makeValidId.js
@@ -3,8 +3,8 @@
     var ID_LOOKUP = {};
     var USED_IDS = {};
 
-    window.shims = window.shims || {};
-    window.shims.makeValidId = function (str) {
+    isic.shims = isic.shims || {};
+    isic.shims.makeValidId = function (str) {
         if (!ID_LOOKUP[str]) {
             var newID = str.replace(/^[^a-z]+|[^\w:.-]+/gi, '');
             var temp = newID;

--- a/web_external/js/views/body/ImagesView/shims/makeValidId.js
+++ b/web_external/js/views/body/ImagesView/shims/makeValidId.js
@@ -9,7 +9,7 @@
             var newID = str.replace(/^[^a-z]+|[^\w:.-]+/gi, '');
             var temp = newID;
             var i = 0;
-            while (USED_IDS.hasOwnProperty(temp)) {
+            while (_.has(USED_IDS, temp)) {
                 i += 1;
                 temp = newID + i;
             }

--- a/web_external/js/views/body/ImagesView/shims/rangeSet.js
+++ b/web_external/js/views/body/ImagesView/shims/rangeSet.js
@@ -105,7 +105,7 @@
 
     function copyRangeList(list) {
         var result = [];
-        list.forEach(function (range, index) {
+        _.each(list, function (range, index) {
             result.push({});
             if ('lowBound' in range) {
                 result[index].lowBound = range.lowBound;
@@ -172,8 +172,8 @@
         list1 = cleanRangeList(list1);
         list2 = cleanRangeList(list2);
         // TODO: there's probably a more efficient way to do this...
-        list1.forEach(function (l1) {
-            list2.forEach(function (l2) {
+        _.each(list1, function (l1) {
+            _.each(list2, function (l2) {
                 var newRange = {
                     lowBound: mostExtremeValue([l1.lowBound, l2.lowBound], '>', comparator, true),
                     highBound: mostExtremeValue([l1.highBound, l2.highBound], '<', comparator, true)
@@ -223,9 +223,9 @@
 
             // Now go through the second list that will hack
             // up the stuff in newRanges
-            list2.forEach(function (l2) {
+            _.each(list2, function (l2) {
                 var indicesToTrash = [];
-                newRanges.forEach(function (newRange, index) {
+                _.each(newRanges, function (newRange, index) {
                     // First, a corner case: if the range to subtract is
                     // entirely inside the original range, we need to
                     // split the original range
@@ -272,7 +272,7 @@
                         }
                     }
                 });
-                indicesToTrash.reverse().forEach(function (i) {
+                _.each(indicesToTrash.reverse(), function (i) {
                     newRanges.splice(i, 1);
                 });
             });

--- a/web_external/js/views/body/ImagesView/shims/rangeSet.js
+++ b/web_external/js/views/body/ImagesView/shims/rangeSet.js
@@ -284,8 +284,8 @@
         return result;
     }
 
-    window.shims = window.shims || {};
-    window.shims.RangeSet = {
+    isic.shims = isic.shims || {};
+    isic.shims.RangeSet = {
         rangeUnion: rangeUnion,
         rangeIntersection: rangeIntersection,
         rangeSubtract: rangeSubtract

--- a/web_external/js/views/body/ImagesView/shims/recolorImageFilters.js
+++ b/web_external/js/views/body/ImagesView/shims/recolorImageFilters.js
@@ -17,7 +17,7 @@ window.shims.recolorImageFilters = function (colorList) {
 
     // Collect all colors in use
     var allColors = {};
-    Object.keys(colorList).forEach(function (colorName) {
+    _.each(Object.keys(colorList), function (colorName) {
         var color = colorList[colorName];
         if (!allColors.hasOwnProperty(color)) {
             allColors[color] = [];

--- a/web_external/js/views/body/ImagesView/shims/recolorImageFilters.js
+++ b/web_external/js/views/body/ImagesView/shims/recolorImageFilters.js
@@ -19,7 +19,7 @@ window.shims.recolorImageFilters = function (colorList) {
     var allColors = {};
     _.each(Object.keys(colorList), function (colorName) {
         var color = colorList[colorName];
-        if (!allColors.hasOwnProperty(color)) {
+        if (!_.has(allColors, color)) {
             allColors[color] = [];
         }
         allColors[color].push(colorName);

--- a/web_external/js/views/body/ImagesView/shims/recolorImageFilters.js
+++ b/web_external/js/views/body/ImagesView/shims/recolorImageFilters.js
@@ -6,8 +6,8 @@
 // -webkit-filter: url(#recolorImageToFFFFFF)
 // filter: url(#recolorImageToFFFFFF)
 
-window.shims = window.shims || {};
-window.shims.recolorImageFilters = function (colorList) {
+isic.shims = isic.shims || {};
+isic.shims.recolorImageFilters = function (colorList) {
     var svgDefs = d3.select('body').append('svg')
         .attr('id', 'recolorImageFilters')
         .attr('width', '0')

--- a/web_external/js/views/body/ImagesView/shims/svgTextWrap.js
+++ b/web_external/js/views/body/ImagesView/shims/svgTextWrap.js
@@ -18,10 +18,10 @@
     function extractWords(element) {
         var words = [];
         // Pull out all the childNodes and split them into words
-        Array.from(element.childNodes).forEach(function (chunk) {
+        _.each(Array.from(element.childNodes), function (chunk) {
             if (chunk.nodeType === window.Node.TEXT_NODE) {
                 // This is an actual text node; split into real words
-                chunk.textContent.split(/\s+/).forEach(function (word) {
+                _.each(chunk.textContent.split(/\s+/), function (word) {
                     if (word.length > 0) {
                         words.push(new window.Text(word));
                     }
@@ -56,7 +56,7 @@
         var currentTspan = newTspan(textElement);
         currentTspan.appendChild(words[0]);
 
-        words.forEach(function (word, index) {
+        _.each(words, function (word, index) {
             // Make a temporary copy of the line
             var tempCopy = currentTspan.cloneNode(true);
 
@@ -88,7 +88,7 @@
         });
 
         // Second pass: line up each row appropriately
-        Array.from(textElement.childNodes).forEach(function (tspan, index) {
+        _.each(Array.from(textElement.childNodes), function (tspan, index) {
             if (index === 0) {
                 // Don't move the first line anywhere
                 tspan.setAttribute('dx', '0px');

--- a/web_external/js/views/body/ImagesView/shims/svgTextWrap.js
+++ b/web_external/js/views/body/ImagesView/shims/svgTextWrap.js
@@ -19,11 +19,11 @@
         var words = [];
         // Pull out all the childNodes and split them into words
         _.each(Array.from(element.childNodes), function (chunk) {
-            if (chunk.nodeType === window.Node.TEXT_NODE) {
+            if (chunk.nodeType === Node.TEXT_NODE) {
                 // This is an actual text node; split into real words
                 _.each(chunk.textContent.split(/\s+/), function (word) {
                     if (word.length > 0) {
-                        words.push(new window.Text(word));
+                        words.push(new Text(word));
                     }
                 });
             } else if (chunk.getAttribute('class') === 'rewrappedTspan') {
@@ -62,7 +62,7 @@
 
             // Add a space if it's not the first word
             if (index > 0) {
-                currentTspan.appendChild(new window.Text(' '));
+                currentTspan.appendChild(new Text(' '));
             }
             // Add the word to the tspan
             currentTspan.appendChild(word);
@@ -117,6 +117,6 @@
         });
     }
 
-    window.shims = window.shims || {};
-    window.shims.rewrapSvgText = rewrap;
+    isic.shims = isic.shims || {};
+    isic.shims.rewrapSvgText = rewrap;
 })();

--- a/web_external/js/views/body/StudiesView.js
+++ b/web_external/js/views/body/StudiesView.js
@@ -5,7 +5,7 @@ isic.views.StudiesView = isic.View.extend({
             var target = $(event.target);
             target.parent().find('.icon-right-open').removeClass('icon-right-open').addClass('icon-down-open');
 
-            var viewIndex = window.parseInt(target.attr('data-model-index'), 10);
+            var viewIndex = parseInt(target.attr('data-model-index'), 10);
             var viewContainer = target.find('.isic-listing-panel-body');
             this.renderStudy(viewIndex, viewContainer);
         },

--- a/web_external/stylesheets/widgets/imageDetailsPage.styl
+++ b/web_external/stylesheets/widgets/imageDetailsPage.styl
@@ -16,3 +16,9 @@ table-header-padding = 0px 8px
       background-color table-header-background-color
       font-weight table-header-font-weight
       padding table-header-padding
+
+.padbottom
+  margin-bottom 3px
+
+.padleft
+  margin-left 5px

--- a/web_external/templates/layout.jade
+++ b/web_external/templates/layout.jade
@@ -6,3 +6,9 @@
 
 #g-dialog-container.modal.fade
 #g-alerts-container
+
+.modal.fade#focusmodal
+  .modal-dialog
+    .modal-content
+      .modal-body
+        img.focusimage

--- a/web_external/templates/widgets/imageDetailsPage.jade
+++ b/web_external/templates/widgets/imageDetailsPage.jade
@@ -4,9 +4,8 @@
 
   if image.id
     .isic-image-details-name= image.name()
-
-    button.btn.btn-large.btn-default.fullscreen Fullscreen
-    button.btn.btn-large.btn-default.openwindow Open in new window
+      button.btn.btn-xs.btn-default.fullscreen Fullscreen
+      button.btn.btn-xs.btn-default.openwindow Open in new window
 
     table.table.table-condensed.isic-image-details-table
       tbody

--- a/web_external/templates/widgets/imageDetailsPage.jade
+++ b/web_external/templates/widgets/imageDetailsPage.jade
@@ -4,8 +4,10 @@
 
   if image.id
     .isic-image-details-name= image.name()
-      button.btn.btn-xs.btn-default.fullscreen Fullscreen
-      button.btn.btn-xs.btn-default.openwindow Open in new window
+      button.btn.btn-xs.btn-default.fullscreen
+        span.glyphicon.glyphicon-zoom-in
+      button.btn.btn-xs.btn-default.openwindow
+        span.glyphicon.glyphicon-new-window
 
     table.table.table-condensed.isic-image-details-table
       tbody

--- a/web_external/templates/widgets/imageDetailsPage.jade
+++ b/web_external/templates/widgets/imageDetailsPage.jade
@@ -6,6 +6,7 @@
     .isic-image-details-name= image.name()
 
     button.btn.btn-large.btn-primary.fullscreen Fullscreen
+    button.btn.btn-large.btn-primary.openwindow Open in new window
 
     table.table.table-condensed.isic-image-details-table
       tbody

--- a/web_external/templates/widgets/imageDetailsPage.jade
+++ b/web_external/templates/widgets/imageDetailsPage.jade
@@ -5,8 +5,8 @@
   if image.id
     .isic-image-details-name= image.name()
 
-    button.btn.btn-large.btn-primary.fullscreen Fullscreen
-    button.btn.btn-large.btn-primary.openwindow Open in new window
+    button.btn.btn-large.btn-default.fullscreen Fullscreen
+    button.btn.btn-large.btn-default.openwindow Open in new window
 
     table.table.table-condensed.isic-image-details-table
       tbody

--- a/web_external/templates/widgets/imageDetailsPage.jade
+++ b/web_external/templates/widgets/imageDetailsPage.jade
@@ -4,9 +4,9 @@
 
   if image.id
     .isic-image-details-name= image.name()
-      button.btn.btn-xs.btn-default.fullscreen
+      button.btn.btn-xs.btn-default.padleft.padbottom.fullscreen
         span.glyphicon.glyphicon-zoom-in
-      button.btn.btn-xs.btn-default.openwindow
+      button.btn.btn-xs.btn-default.padleft.padbottom.openwindow
         span.glyphicon.glyphicon-new-window
 
     table.table.table-condensed.isic-image-details-table

--- a/web_external/templates/widgets/imageDetailsPage.jade
+++ b/web_external/templates/widgets/imageDetailsPage.jade
@@ -4,9 +4,9 @@
 
   if image.id
     .isic-image-details-name= image.name()
-      button.btn.btn-xs.btn-default.padleft.padbottom.fullscreen
+      button.btn.btn-xs.btn-default.padleft.padbottom.fullscreen(data-toggle="tooltip" data-placement="bottom" title="View this image in full resolution")
         span.glyphicon.glyphicon-zoom-in
-      button.btn.btn-xs.btn-default.padleft.padbottom.openwindow
+      button.btn.btn-xs.btn-default.padleft.padbottom.openwindow(data-toggle="tooltip" data-placement="bottom" title="Open this image in a new window")
         span.glyphicon.glyphicon-new-window
 
     table.table.table-condensed.isic-image-details-table

--- a/web_external/templates/widgets/imageDetailsPage.jade
+++ b/web_external/templates/widgets/imageDetailsPage.jade
@@ -5,6 +5,8 @@
   if image.id
     .isic-image-details-name= image.name()
 
+    button.btn.btn-large.btn-primary.fullscreen Fullscreen
+
     table.table.table-condensed.isic-image-details-table
       tbody
         tr


### PR DESCRIPTION
This PR removes the double click logic that used to open an image in a new tab. In its place, the detail menu that appears when an image is selected includes two new buttons: one labeled "fullscreen" and another labeled "open in new window".

The "open in new window" button takes over the behavior of the double click action - a new window is opened to display the image in full resolution.

The "fullscreen" button opens a Bootstrap modal without a header or footer (so it looks just like what a dedicated lightbox library would provide) showing the full resolution image. The modal is sized appropriately to accommodate the image, and it appears centered in the browser window, even on resizing.

Closes #138 

Depends on #177 