### PR TITLE
Open fullscreen modal with shift-click

### DIFF
--- a/web_external/js/init.js
+++ b/web_external/js/init.js
@@ -6,6 +6,7 @@ _.extend(isic, {
     models: {},
     collections: {},
     views: {},
+    util: {},
     router: new Backbone.Router(),
     events: girder.events
 });

--- a/web_external/js/views/body/ImagesView/ImageDetailsPane.js
+++ b/web_external/js/views/body/ImagesView/ImageDetailsPane.js
@@ -1,5 +1,46 @@
 isic.views.ImagesViewSubViews = isic.views.ImagesViewSubViews || {};
 
+isic.util.fullscreen = function (id) {
+    var img = $('.focusimage');
+    var modal = $('#focusmodal');
+
+    // Supply the image element with a new src attribute to display the image.
+    var src = '/api/v1/image/' + id + '/download?contentDisposition=inline';
+    img.attr('src', src);
+
+    // Create a dummy image element so we can learn the size of the new image.
+    // When the image is loaded, we can use its size to properly resize and
+    // situate the modal.
+    var image = new Image();
+    image.onload = function () {
+        // Add thirty to represent the 15px padding that comes stock with a
+        // Bootstrap modal.
+        var modalWidth = image.width + 30;
+        var modalHeight = image.height + 30;
+
+        // Set the CSS of the dialog so it appears vertically and horizontally
+        // centered in the webpage (even with browser resizing).
+        modal.find('.modal-dialog').css({
+            width: modalWidth + 'px',
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            'margin-top': (-modalHeight / 2) + 'px',
+            'margin-left': (-modalWidth / 2) + 'px'
+        });
+
+        // Now that the image and CSS are ready, show the modal.
+        modal.modal('show');
+    };
+
+    // Allow clicking on the image itself to dismiss the modal.
+    img.on('click.dismiss', function () {
+        $('#focusmodal').modal('hide');
+    });
+
+    image.src = src;
+};
+
 // View for image details
 isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
     events: {
@@ -77,46 +118,8 @@ isic.views.ImagesViewSubViews.ImageDetailsPane = isic.View.extend({
     },
 
     fullscreen: function () {
-        this.clearTooltips();
-
-        var img = $('.focusimage');
-        var modal = $('#focusmodal');
-
-        // Supply the image element with a new src attribute to display the image.
-        var src = '/api/v1/image/' + this.image.id + '/download?contentDisposition=inline';
-        img.attr('src', src);
-
-        // Create a dummy image element so we can learn the size of the new image.
-        // When the image is loaded, we can use its size to properly resize and
-        // situate the modal.
-        var image = new Image();
-        image.onload = function () {
-            // Add thirty to represent the 15px padding that comes stock with a
-            // Bootstrap modal.
-            var modalWidth = image.width + 30;
-            var modalHeight = image.height + 30;
-
-            // Set the CSS of the dialog so it appears vertically and horizontally
-            // centered in the webpage (even with browser resizing).
-            modal.find('.modal-dialog').css({
-                width: modalWidth + 'px',
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                'margin-top': (-modalHeight / 2) + 'px',
-                'margin-left': (-modalWidth / 2) + 'px'
-            });
-
-            // Now that the image and CSS are ready, show the modal.
-            modal.modal('show');
-        };
-
-        // Allow clicking on the image itself to dismiss the modal.
-        img.on('click.dismiss', function () {
-            $('#focusmodal').modal('hide');
-        });
-
-        image.src = src;
+      this.clearTooltips();
+      isic.util.fullscreen(this.image.id);
     },
 
     clearSelectedImage: function () {

--- a/web_external/js/views/body/ImagesView/ImageWall.js
+++ b/web_external/js/views/body/ImagesView/ImageWall.js
@@ -42,7 +42,11 @@ isic.views.ImagesViewSubViews.ImageWall = Backbone.View.extend({
                 return d === this.image.id;
             }, this))
             .on('click', _.bind(function (d) {
-                this.selectImage(d === this.image.id ? null : d)
+                if (d3.event.shiftKey) {
+                    isic.util.fullscreen(d);
+                } else {
+                    this.selectImage(d === this.image.id ? null : d)
+                }
             }, this));
     }, 50)
 });


### PR DESCRIPTION
In addition to clicking on the magnifying glass icon in the details pane, you can now shift-click on any image in the thumbnail pane to get the zoomed view of that image.

Closes #197 