### PR TITLE
Clarify multi-component names on featureset page

### DIFF
--- a/web_external/stylesheets/body/featuresetPage.styl
+++ b/web_external/stylesheets/body/featuresetPage.styl
@@ -17,6 +17,11 @@
       padding-top 10px
       font-size 16px
 
+      .isic-featureset-table-feature-name-component
+        padding 2px 6px
+        background-color #e8f1f5
+        border-radius 4px
+
     .isic-featureset-table-feature-id-key
     .isic-featureset-table-feature-id-value
     .isic-featureset-table-feature-value-label-id

--- a/web_external/templates/body/featuresetPage.jade
+++ b/web_external/templates/body/featuresetPage.jade
@@ -28,7 +28,7 @@
                 tr
                   td.isic-featureset-table-feature-header(colspan=3)
                     each nameComponent, index in feature.name
-                      = nameComponent
+                      span.isic-featureset-table-feature-name-component= nameComponent
                       if index < (feature.name.length - 1)
                         i.icon-angle-right
                 tr

--- a/web_external/templates/body/featuresetPage.jade
+++ b/web_external/templates/body/featuresetPage.jade
@@ -26,7 +26,11 @@
               each feature in featureset.get(featureType.id)
                 - var hasOptions = (feature.type === 'radio');
                 tr
-                  td.isic-featureset-table-feature-header(colspan=3)= feature.name.join(', ')
+                  td.isic-featureset-table-feature-header(colspan=3)
+                    each nameComponent, index in feature.name
+                      = nameComponent
+                      if index < (feature.name.length - 1)
+                        i.icon-angle-right
                 tr
                   td.isic-featureset-table-label.isic-featureset-table-feature-id-key ID
                   td.isic-featureset-table-feature-id-value


### PR DESCRIPTION
Add a separator between feature name components. The separator suggests a hierarchical relationship between the components.

Fixes #230 