### PR TITLE
Check whether image viewer widget exists before destroying it

### DIFF
--- a/web_external/js/views/widgets/ImageFullscreenWidget.js
+++ b/web_external/js/views/widgets/ImageFullscreenWidget.js
@@ -9,8 +9,10 @@ isic.views.ImageFullscreenWidget = isic.View.extend({
                 parentView: this
             });
         }, this)).on('hidden.bs.modal', _.bind(function () {
-            this.imageViewerWidget.destroy();
-            delete this.imageViewerWidget;
+            if (this.imageViewerWidget) {
+                this.imageViewerWidget.destroy();
+                delete this.imageViewerWidget;
+            }
         }, this));
     }
 });


### PR DESCRIPTION
I hit this when navigating away from Lesion Images after viewing an image.