### PR TITLE
Allow closing modal dialogs by pressing Escape

### DIFF
--- a/web_external/templates/layout.jade
+++ b/web_external/templates/layout.jade
@@ -4,5 +4,8 @@
 
 #g-app-progress-container
 
-#g-dialog-container.modal.fade
+// Set tabindex on modal element to allow closing modal by pressing Escape. See:
+// - http://getbootstrap.com/javascript/#modals-examples
+// - http://stackoverflow.com/questions/12630156/
+#g-dialog-container.modal.fade(tabindex="-1")
 #g-alerts-container


### PR DESCRIPTION
It's useful to be able to close a modal dialog by pressing escape
instead of using the mouse. This commit fixes an issue with the key
events being handled as desired by preventing keyboard focus on the
top-level modal element. This is consistent with the Bootstrap modal
examples: http://getbootstrap.com/javascript/#modals-examples

Also see:
http://stackoverflow.com/questions/12630156/