### PR TITLE
Add license info modal dialog to Upload Dataset

### DIFF
--- a/web_external/js/views/body/UploadDatasetView.js
+++ b/web_external/js/views/body/UploadDatasetView.js
@@ -15,6 +15,7 @@ isic.views.UploadDatasetView = isic.View.extend({
         'click #isic-upload-reset': function (event) {
             this.resetUpload();
         },
+        'click .isic-dataset-agreement-link': 'showLicenseInfo',
         'change input[name="attribution"]': function (event) {
             // Update attribution name field sensitivity
             var target = $(event.target);
@@ -241,6 +242,16 @@ isic.views.UploadDatasetView = isic.View.extend({
                 folderId: this.uploadFolder.id
             });
         }, this);
+    },
+
+    showLicenseInfo: function () {
+        if (!this.licenseInfoWidget) {
+            this.licenseInfoWidget = new isic.views.UploadDatasetLicenseInfoWidget({
+                el: $('#g-dialog-container'),
+                parentView: this
+            });
+        }
+        this.licenseInfoWidget.render();
     }
 });
 

--- a/web_external/js/views/widgets/UploadDatasetLicenseInfoWidget.js
+++ b/web_external/js/views/widgets/UploadDatasetLicenseInfoWidget.js
@@ -1,0 +1,7 @@
+// Modal view for dataset license information
+isic.views.UploadDatasetLicenseInfoWidget = isic.View.extend({
+    render: function () {
+        this.$el.html(isic.templates.uploadDatasetLicenseInfoPage()).girderModal(this);
+        return this;
+    }
+});

--- a/web_external/stylesheets/widgets/uploadDatasetLicenseInfoPage.styl
+++ b/web_external/stylesheets/widgets/uploadDatasetLicenseInfoPage.styl
@@ -1,0 +1,12 @@
+.isic-upload-dataset-license-info-container
+  width 60%
+
+  .modal-body
+    max-height 80vh
+    overflow-y auto
+
+    .isic-upload-dataset-license-info-title:first-child
+      margin-top 0px
+
+    .isic-upload-dataset-license-info-title
+      margin-top 25px

--- a/web_external/stylesheets/widgets/uploadDatasetLicenseInfoPage.styl
+++ b/web_external/stylesheets/widgets/uploadDatasetLicenseInfoPage.styl
@@ -5,6 +5,15 @@
     max-height 80vh
     overflow-y auto
 
+    .alert
+      display flex
+      .isic-upload-dataset-license-info-alert-icon
+        font-size 30px
+      .isic-upload-dataset-license-info-alert-content
+        flex 1
+        font-size 16px
+        margin-left 5px
+
     .isic-upload-dataset-license-info-title:first-child
       margin-top 0px
 

--- a/web_external/stylesheets/widgets/uploadDatasetLicenseInfoPage.styl
+++ b/web_external/stylesheets/widgets/uploadDatasetLicenseInfoPage.styl
@@ -7,11 +7,9 @@
 
     .alert
       display flex
-      .isic-upload-dataset-license-info-alert-icon
-        font-size 30px
+      font-size 16px
       .isic-upload-dataset-license-info-alert-content
         flex 1
-        font-size 16px
         margin-left 5px
 
     .isic-upload-dataset-license-info-title:first-child

--- a/web_external/templates/widgets/uploadDatasetLicenseInfoPage.jade
+++ b/web_external/templates/widgets/uploadDatasetLicenseInfoPage.jade
@@ -5,6 +5,11 @@
       h4.modal-title
         | Licenses
     .modal-body
+      .alert.alert-info(role="alert")
+        i.icon-attention-circled.isic-upload-dataset-license-info-alert-icon
+        .isic-upload-dataset-license-info-alert-content
+          | The ISIC strongly recommends that dataset contributors choose the <b>CC-0</b> or <b>CC-BY</b> licenses whenever possible.
+
       h4.isic-upload-dataset-license-info-title
         p
           img(src="https://licensebuttons.net/l/zero/1.0/88x31.png")

--- a/web_external/templates/widgets/uploadDatasetLicenseInfoPage.jade
+++ b/web_external/templates/widgets/uploadDatasetLicenseInfoPage.jade
@@ -6,7 +6,7 @@
         | Licenses
     .modal-body
       .alert.alert-info(role="alert")
-        i.icon-attention-circled.isic-upload-dataset-license-info-alert-icon
+        i.icon-attention-circled
         .isic-upload-dataset-license-info-alert-content
           | The ISIC strongly recommends that dataset contributors choose the <b>CC-0</b> or <b>CC-BY</b> licenses whenever possible.
 

--- a/web_external/templates/widgets/uploadDatasetLicenseInfoPage.jade
+++ b/web_external/templates/widgets/uploadDatasetLicenseInfoPage.jade
@@ -1,0 +1,49 @@
+.modal-dialog.isic-upload-dataset-license-info-container
+  .modal-content
+    .modal-header
+      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      h4.modal-title
+        | Licenses
+    .modal-body
+      h4.isic-upload-dataset-license-info-title
+        p
+          img(src="https://licensebuttons.net/l/zero/1.0/88x31.png")
+        | CC-0 (No restrictions)
+      p.
+        CC-0 enables scientists, educators, artists and other creators and
+        owners of copyright- or database-protected content to waive those
+        interests in their works and thereby place them as completely as
+        possible in the public domain, so that others may freely build upon,
+        enhance and reuse the works for any purposes without restriction under
+        copyright or database law.
+      a(href="https://creativecommons.org/publicdomain/zero/1.0/", target="_blank")
+        | View License Deed&nbsp;
+        i.icon-link-ext
+
+      h4.isic-upload-dataset-license-info-title
+        p
+          img(src="https://licensebuttons.net/l/by/4.0/88x31.png")
+        | CC-BY (Attribution)
+      p.
+        This license lets others distribute, remix, tweak, and build upon your
+        work, even commercially, as long as they credit you for the original
+        creation.
+      a(href="https://creativecommons.org/licenses/by/4.0", target="_blank")
+        | View License Deed&nbsp;
+        i.icon-link-ext
+
+      h4.isic-upload-dataset-license-info-title
+        p
+          img(src="https://licensebuttons.net/l/by-nc/4.0/88x31.png")
+        | CC-BY-NC (Attribution-NonCommercial)
+      p.
+        This license lets others remix, tweak, and build upon your work
+        non-commercially, and although their new works must also acknowledge
+        you and be non-commercial, they don’t have to license their derivative
+        works on the same terms.
+      a(href="https://creativecommons.org/licenses/by-nc/4.0", target="_blank")
+        | View License Deed&nbsp;
+        i.icon-link-ext
+
+    .modal-footer
+      a.btn.btn-small.btn-primary(data-dismiss="modal") Close


### PR DESCRIPTION
Show license information in a modal dialog when the user clicks "Help me
choose." The information includes a brief summary and link to the
license deed for each license.

Fixes #169 
