### PR TITLE
Hide comment in generated HTML

### DIFF
--- a/web_external/templates/layout.jade
+++ b/web_external/templates/layout.jade
@@ -4,8 +4,8 @@
 
 #g-app-progress-container
 
-// Set tabindex on modal element to allow closing modal by pressing Escape. See:
-// - http://getbootstrap.com/javascript/#modals-examples
-// - http://stackoverflow.com/questions/12630156/
+//- Set tabindex on modal element to allow closing modal by pressing Escape. See:
+//- - http://getbootstrap.com/javascript/#modals-examples
+//- - http://stackoverflow.com/questions/12630156/
 #g-dialog-container.modal.fade(tabindex="-1")
 #g-alerts-container


### PR DESCRIPTION
Hide the comment about tabindex on the modal dialog container in the
generated HTML. Although some comments in the jade templates are useful
to see in the generated HTML, this specific one is not and is
distracting to see at the top level of the body when inspecting the
page.