### PR TITLE
Add links to Terms of Use and Privacy Policy in footer

### DIFF
--- a/web_external/js/views/layout/FooterView.js
+++ b/web_external/js/views/layout/FooterView.js
@@ -11,7 +11,7 @@ isic.views.LayoutFooterView = isic.View.extend({
         this.$('.isic-footer-disclaimer').popover({
             trigger: 'hover',
             placement: 'auto top',
-            container: this.$('.isic-footer-links')
+            container: this.$('.isic-footer-legal')
         }).click(function () {
             $(this).popover('toggle');
         });

--- a/web_external/stylesheets/layout.styl
+++ b/web_external/stylesheets/layout.styl
@@ -61,23 +61,34 @@ $textColor = #444
   padding 0 !important
 
 #isic-app-footer-container
-  display flex
   border-top 1px solid #eee
   background-image linear-gradient(to bottom, #f6f6f6 0%, #fff 5px)
-  padding 5px 10px 0px 10px
+  padding-top 5px
+  white-space nowrap
 
   ul
-    display flex
     list-style none
     padding 0px
 
-  // Add vertical line separator before list items, except the first
+  li
+    //- Lay out horizontally
+    display inline-block
+
+  //- Add vertical line separator before list items, except the first
   li + li
     &:before
       content '\2502'
       padding 0em 0.5em
 
+  //- Default section alignment
   .isic-footer-legal
-    flex 1
-    display flex
-    justify-content center
+    text-align center
+  .isic-footer-links
+    text-align right
+
+  //- 'sm' grid tier and below section alignment
+  @media (max-width: 991px)
+    .isic-footer-legal
+      text-align left
+    .isic-footer-links
+      text-align left

--- a/web_external/stylesheets/layout.styl
+++ b/web_external/stylesheets/layout.styl
@@ -77,5 +77,7 @@ $textColor = #444
       content '\2502'
       padding 0em 0.5em
 
-  .isic-footer-info
+  .isic-footer-legal
     flex 1
+    display flex
+    justify-content center

--- a/web_external/templates/layout/layoutFooter.jade
+++ b/web_external/templates/layout/layoutFooter.jade
@@ -1,25 +1,27 @@
-.isic-footer-info
-  ul
-    li
-      | &copy; Kitware, Inc.
-    li
-      | Powered by
-      a#g-about-link(href="http://girder.readthedocs.org/en/latest/user-guide.html")  Girder
+.container-fluid
+  .row
+    .isic-footer-info.col-md-4
+      ul
+        li
+          | &copy; Kitware, Inc.
+        li
+          | Powered by
+          a#g-about-link(href="http://girder.readthedocs.org/en/latest/user-guide.html")  Girder
 
-.isic-footer-legal
-  ul
-    li
-      a(href="#termsOfUse") Terms of Use
-    li
-      a(href="#privacyPolicy") Privacy Policy
-    li.isic-footer-disclaimer(data-content="All information on this website is for education and information purposes only. For specific medical advice, diagnoses, and treatment, seek expert, specific medical care. Click the link below to see our Medical Disclaimer in its entirety.")
-      a(href="#medicalDisclaimer") Medical Disclaimer
+    .isic-footer-legal.col-md-4
+      ul
+        li
+          a(href="#termsOfUse") Terms of Use
+        li
+          a(href="#privacyPolicy") Privacy Policy
+        li.isic-footer-disclaimer(data-content="All information on this website is for education and information purposes only. For specific medical advice, diagnoses, and treatment, seek expert, specific medical care. Click the link below to see our Medical Disclaimer in its entirety.")
+          a(href="#medicalDisclaimer") Medical Disclaimer
 
-.isic-footer-links
-  ul
-    li
-      a#g-contact-link(href="mailto:admin@isic-archive.com") Contact
-    li
-      a(href="#{apiRoot}") Web API
-    li
-      a#g-bug-link(href="https://github.com/ImageMarkup/isic-archive/issues/new") Report a bug
+    .isic-footer-links.col-md-4
+      ul
+        li
+          a#g-contact-link(href="mailto:admin@isic-archive.com") Contact
+        li
+          a(href="#{apiRoot}") Web API
+        li
+          a#g-bug-link(href="https://github.com/ImageMarkup/isic-archive/issues/new") Report a bug

--- a/web_external/templates/layout/layoutFooter.jade
+++ b/web_external/templates/layout/layoutFooter.jade
@@ -1,4 +1,3 @@
-
 .isic-footer-info
   ul
     li
@@ -7,10 +6,17 @@
       | Powered by
       a#g-about-link(href="http://girder.readthedocs.org/en/latest/user-guide.html")  Girder
 
-.isic-footer-links
+.isic-footer-legal
   ul
+    li
+      a(href="#termsOfUse") Terms of Use
+    li
+      a(href="#privacyPolicy") Privacy Policy
     li.isic-footer-disclaimer(data-content="All information on this website is for education and information purposes only. For specific medical advice, diagnoses, and treatment, seek expert, specific medical care. Click the link below to see our Medical Disclaimer in its entirety.")
       a(href="#medicalDisclaimer") Medical Disclaimer
+
+.isic-footer-links
+  ul
     li
       a#g-contact-link(href="mailto:admin@isic-archive.com") Contact
     li


### PR DESCRIPTION
Fixes #279 

One thing to note is that the footer doesn't currently collapse very reasonably when the available width is small. I investigated using Bootstrap's grid system, but AFAIK that doesn't allow full-width containers out of the box, so the left and right text wouldn't be aligned to the left and right of the window.