### PR TITLE
Rename special histogram bin values

### DIFF
--- a/server/histogram_utility/__init__.py
+++ b/server/histogram_utility/__init__.py
@@ -171,7 +171,7 @@ class HistogramUtility(object):
             binSettings[attrName]['specialBins'] = specialBins
 
             # Get user-defined or default number of bins
-            numBins = binSettings[attrName].get('numBins', 10)
+            numBins = binSettings[attrName].get('numBins', 0)
             binSettings[attrName]['numBins'] = numBins
 
             # For ordinal binning, we need some more details:

--- a/server/histogram_utility/binUtils.js
+++ b/server/histogram_utility/binUtils.js
@@ -21,6 +21,10 @@ function coerceValue(value, coerceToType) {
     } else if (coerceToType === 'string') {
         if (value && value.str) {
             value = value.str;
+        } else if (value === undefined) {
+            value = '__undefined__';
+        } else if (value === null) {
+            value = '__null__';
         } else {
             value = String(value);
         }
@@ -263,13 +267,13 @@ function findBinLabel(value, coerceToType, lowBound, highBound, specialBins, ord
     }
 
     // Is the value a special value (always emit the value directly)?
-    if (value === undefined || value === 'undefined') {
-        return 'undefined';
-    } else if (value === null || value === 'null') {
-        return 'null';
+    if (value === undefined || value === '__undefined__') {
+        return '__undefined__';
+    } else if (value === null || value === '__null__') {
+        return '__null__';
     } else if (isNaN(value)) {
         if (coerceToType === 'number' || coerceToType === 'integer') {
-            return 'NaN';
+            return '__NaN__';
         } else if (value instanceof Date) {
             return 'Invalid Date';
         }
@@ -328,7 +332,7 @@ function findBinLabel(value, coerceToType, lowBound, highBound, specialBins, ord
         }
         // Okay, the value didn't make it into any of the ordinal bins.
         // The bins must not include the full range of the data.
-        return 'other';
+        return '__other__';
     }
 }
 

--- a/server/histogram_utility/histogram_reduce.js
+++ b/server/histogram_utility/histogram_reduce.js
@@ -78,8 +78,9 @@ allHistograms.forEach(function (wrappedHistogram) {
             }
             specialBins[bin.label].count += bin.count;
         } else {
-            // This is a regular value that we don't have a bin for. Do we have space?
-            if (histogram.length < binSettings.numBins) {
+            // This is a regular value that we don't have a bin for.
+            // Are we not limiting bins or do we have space?
+            if (!binSettings.numBins || histogram.length < binSettings.numBins) {
                 // We still have room; create a new bin
                 // TODO: do the fancier stuff outlined at the top of this file
                 binLookup[bin.label] = histogram.length;

--- a/server/histogram_utility/histogram_reduce.js
+++ b/server/histogram_utility/histogram_reduce.js
@@ -2,7 +2,7 @@
 
 /*
 TODO: For now, we keep the first m categorical values that we encounter,
-and throw the rest into an "other" bin.
+and throw the rest into an "__other__" bin.
 
 Instead, we *SHOULD* count the top m-most frequent values...:
 Pass #1:
@@ -25,14 +25,14 @@ var histogram = [];
 var specialBins = {};
 var binLookup = {};
 var specialValues = {
-    'undefined': true,
-    'null': true,
-    'NaN': true,
+    '__undefined__': true,
+    '__null__': true,
+    '__NaN__': true,
     'Infinity': true,
     '-Infinity': true,
     '"" (empty string)': true,
     'Invalid Date': true,
-    'other': true
+    '__other__': true
 };
 
 var binSettings = params.binSettings[attrName];
@@ -88,14 +88,14 @@ allHistograms.forEach(function (wrappedHistogram) {
                     count: bin.count
                 });
             } else {
-                // Okay, there's no room left. Add a count to the special "other" bin
-                if (!(specialBins.hasOwnProperty('other'))) {
-                    specialBins['other'] = {
-                        label: 'other',
+                // Okay, there's no room left. Add a count to the special "__other__" bin
+                if (!(specialBins.hasOwnProperty('__other__'))) {
+                    specialBins['__other__'] = {
+                        label: '__other__',
                         count: 0
                     };
                 }
-                specialBins['other'].count += bin.count;
+                specialBins['__other__'].count += bin.count;
             }
         }
     });
@@ -111,12 +111,12 @@ if (!binSettings.ordinalBins) {
 }
 
 // Okay, add the special bins on to the end of the regular ones
-// (starting with "other" if it exists)
-if (specialBins.hasOwnProperty('other')) {
-    histogram.push(specialBins['other']);
+// (starting with "__other__" if it exists)
+if (specialBins.hasOwnProperty('__other__')) {
+    histogram.push(specialBins['__other__']);
 }
 Object.keys(specialBins).forEach(function (bin) {
-    if (bin !== 'other') {
+    if (bin !== '__other__') {
         histogram.push(specialBins[bin]);
     }
 });

--- a/server/histogram_utility/querylang.py
+++ b/server/histogram_utility/querylang.py
@@ -157,8 +157,12 @@ def _astToMongo_helper(ast):
             value = map(lambda x: cast(x, 'objectid'), value)
 
         if operator in ['in', 'not in']:
-            value = map(lambda x: None if x in ['NaN', 'undefined'] else x,
-                        value)
+            value = map(
+                lambda x:
+                    None
+                    if x in ['__null__', '__NaN__', '__undefined__']
+                    else x,
+                value)
 
         return {field: {_mongo_operators[operator]: value}}
 

--- a/web_external/js/views/body/ImagesView/ImagesFacetView.js
+++ b/web_external/js/views/body/ImagesView/ImagesFacetView.js
@@ -10,7 +10,7 @@ isic.views.ImagesFacetView = isic.View.extend({
     className: 'isic-images-facet',
 
     _getFieldLabel: function (fieldInfo) {
-        if (fieldInfo.label === 'NaN' || fieldInfo.label === 'undefined') {
+        if (fieldInfo.label === '__NaN__' || fieldInfo.label === '__undefined__') {
             return 'unknown';
         } else if (_.has(fieldInfo, 'lowBound')) {
             var formatter = d3.format('0.3s');

--- a/web_external/js/views/body/ImagesView/ImagesViewModel.js
+++ b/web_external/js/views/body/ImagesView/ImagesViewModel.js
@@ -84,18 +84,18 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
         }, this));
     },
     postProcessHistogram: function (histograms) {
-        // This folds any "null" values into "undefined" or "NaN" values,
-        // mutating the "histograms" object in-place
+        // This folds any "__null__" values into "__undefined__" or "__NaN__"
+        // values, mutating the "histograms" object in-place
         _.each(_.keys(histograms), function (facetName) {
             if (facetName === '__passedFilters__') {
                 return;
             }
             var facetHistogram = histograms[facetName];
-            var nullField = _.findWhere(facetHistogram, {label: 'null'});
+            var nullField = _.findWhere(facetHistogram, {label: '__null__'});
             if (nullField) {
                 var missingField =
-                    _.findWhere(facetHistogram, {label: 'undefined'}) ||
-                    _.findWhere(facetHistogram, {label: 'NaN'});
+                    _.findWhere(facetHistogram, {label: '__undefined__'}) ||
+                    _.findWhere(facetHistogram, {label: '__NaN__'});
                 if (missingField) {
                     // Add the null value to "missing" field
                     missingField.count += nullField.count;
@@ -107,9 +107,9 @@ isic.views.ImagesViewSubViews.ImagesViewModel = Backbone.Model.extend({
                         return _.has(field, 'lowBound') || _.has(field, 'highBound');
                     });
                     if (isOrdinalFacet) {
-                        nullField.label = 'undefined';
+                        nullField.label = '__NaN__';
                     } else {
-                        nullField.label = 'NaN';
+                        nullField.label = '__undefined__';
                     }
                 }
             }


### PR DESCRIPTION
This renames the special bin values  `"__undefined__"`, `"__null__"`, `"__NaN__"`, `"__other__"` to reduce the likelihood of collisions with actual data bin values.

This also defaults to [not putting excess histogram bins into `"__other__"`](https://github.com/ImageMarkup/isic-archive/pull/298/files#diff-7a5c68fa12d300ef580a972414f7ddf0R83), when `numBins` is not defined for a histogram. Previously, any additional values, after the [first 10 distinct ones](https://github.com/ImageMarkup/isic-archive/pull/298/files#diff-ae0e0f9d696bd994644cb93b0cab2c20R174), would be placed into an `"other"` bin.

This ensures that [`"__null__"` values sent by the client](https://github.com/ImageMarkup/isic-archive/pull/298/files#diff-1bd33893522244904a198aa9d73f68edR163) when creating a filter are converted into proper `None` values, though this does not have any effect with the current client configuration (which transforms all `"__null__"` into `"__undefined__"` or `"__NaN__"`).

This fixes a minor bug where the client was [transforming `"__null__"` into](https://github.com/ImageMarkup/isic-archive/pull/298/files#diff-5ab9722391177e1811dc3aca6cbbdd3dL110) the wrong one of `"__undefined__"` or `"__NaN__"`.