### PR TITLE
Improve Python 3 compatability

### DIFF
--- a/server/api/study.py
+++ b/server/api/study.py
@@ -24,6 +24,7 @@ import itertools
 import json
 
 import cherrypy
+import six
 
 from girder.api import access
 from girder.api.rest import Resource, RestException, loadmodel, \
@@ -205,14 +206,14 @@ class StudyResource(Resource):
 
                 # TODO: move this into the query
                 if 'localFeatures' in annotation['meta']['annotations']:
-                    superpixelCount = len(
-                        annotation['meta']['annotations']['localFeatures'].itervalues().next())  # noqa: E501
+                    superpixelCount = len(next(six.viewvalues(
+                        annotation['meta']['annotations']['localFeatures'])))
                     for superpixelMum in xrange(superpixelCount):
 
                         outDict = outDictBase.copy()
                         outDict['superpixel_id'] = superpixelMum
-                        for featureName, featureValue in \
-                                annotation['meta']['annotations']['localFeatures'].iteritems():  # noqa: E501
+                        for featureName, featureValue in six.viewitems(
+                                annotation['meta']['annotations']['localFeatures']):  # noqa: E501
                             outDict[featureName] = featureValue[superpixelMum]
 
                         csvWriter.writerow(outDict)

--- a/server/api/task.py
+++ b/server/api/task.py
@@ -378,7 +378,7 @@ class TaskResource(Resource):
                 limit=1,
                 sort=[('lowerName', SortDir.ASCENDING)]
             )
-            nextAnnotation = activeAnnotations.next()
+            nextAnnotation = next(activeAnnotations)
         except StopIteration:
             raise RestException('No annotations are needed for this study.')
 

--- a/server/histogram_utility/__init__.py
+++ b/server/histogram_utility/__init__.py
@@ -22,10 +22,12 @@ import json
 
 import cherrypy
 import execjs
-from querylang import astToMongo
+import six
 
 from girder.api.rest import RestException
 from girder.utility.model_importer import ModelImporter
+
+from .querylang import astToMongo
 
 
 TRUE_VALUES = set([True, 'true', 1, 'True'])
@@ -148,7 +150,7 @@ class HistogramUtility(object):
             params['filter'] = json.loads(params['filter'])
 
         binSettings = json.loads(params.get('binSettings', '{}'))
-        for attrName in binSettings.iterkeys():
+        for attrName in six.viewkeys(binSettings):
             binSettings[attrName] = binSettings.get(attrName, {})
 
             # Get user-defined or default type coercion setting
@@ -255,7 +257,7 @@ class HistogramUtility(object):
         # We have to clean up the histogram wrappers (mongodb can't return
         # an array from reduce functions). While we're at it, add the
         # lowBound / highBound details to each ordinal bin
-        for attrName, wrappedHistogram in histogram.iteritems():
+        for attrName, wrappedHistogram in six.viewitems(histogram):
             histogram[attrName] = wrappedHistogram['histogram']
 
         if '__passedFilters__' not in histogram:

--- a/server/upload.py
+++ b/server/upload.py
@@ -180,7 +180,7 @@ def handleCsv(dataset, prereviewFolder, user, csvFile):
                     filename)
                 continue
             else:
-                imageItem = imageItems.next()
+                imageItem = next(imageItems)
 
             unstructuredMetadata = imageItem['meta']['unstructured']
             unstructuredMetadata.update(csvRow)


### PR DESCRIPTION
* Use the next() builtin instead of the .next() method of iterators
* Use compatability methods to iterate over dicts