### PR TITLE
Fix a bug in how the local feature array is created

### DIFF
--- a/custom/static/js/pixelmap.js
+++ b/custom/static/js/pixelmap.js
@@ -188,7 +188,7 @@ Pixelmap.prototype.activate = function (featureValues) {
     }, this));
 
     if (featureValues === undefined) {
-        featureValues = new Array(this.pixelmap.maxIndex());
+        featureValues = new Array(this.pixelmap.maxIndex() + 1);
         for (var i = 0, len = featureValues.length; i < len; ++i) {
             featureValues[i] = Pixelmap.State.ABSENT;
         }


### PR DESCRIPTION
This does not affect the accuracy of any existing annotations, since JS will always include the final array element if it's actually set. Existing annotations should be migrated to add an extra "0" value, to make the new validation pass.