### PR TITLE
Improve upload widget drop zone style

### DIFF
--- a/web_external/Datasets/uploadWidget.styl
+++ b/web_external/Datasets/uploadWidget.styl
@@ -9,7 +9,7 @@
     font-color #eee
 
   .g-drop-zone
-    width 100%
+    width 40%
     text-align center
     height 60px
     line-height 60px
@@ -34,13 +34,15 @@
       background white
       border 2px dashed #bbb
       box-shadow none
-      padding 0
+      height 60px
+      // Center content horizontally and vertically
+      display flex
+      align-items center
+      justify-content center
 
 .isic-upload-widget-container
   padding 10px 0px
   text-align left
-  display inline-block
-  max-width 370px
 
   .g-dialog-subtitle
     display none


### PR DESCRIPTION
This commit improves the style applied to the upload widget, especially
with regards to drag and drop.

The drop zone is taller and wider. This makes it easier to drag and drop
to upload a file.

Additionally, the width of "Browse or drop files" button no longer
depends on the width of the text below (which changes after uploading a
file).