### PR TITLE
Set rawResponse on APIs after error checking has concluded

### DIFF
--- a/server/api/annotation.py
+++ b/server/api/annotation.py
@@ -20,8 +20,8 @@
 import datetime
 
 from girder.api import access
-from girder.api.rest import Resource, RestException, loadmodel, rawResponse, \
-    setResponseHeader
+from girder.api.rest import Resource, RestException, loadmodel, \
+    setRawResponse, setResponseHeader
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType
 
@@ -154,7 +154,6 @@ class AnnotationResource(Resource):
     )
     @access.cookie
     @access.public
-    @rawResponse
     @loadmodel(model='annotation', plugin='isic_archive', level=AccessType.READ)
     def renderAnnotation(self, annotation, params):
         Study = self.model('study', 'isic_archive')
@@ -184,6 +183,9 @@ class AnnotationResource(Resource):
             renderData, 'jpeg')
         renderEncodedData = renderEncodedStream.getvalue()
 
+        # Only setRawResponse now, as this handler may return a JSON error
+        # earlier
+        setRawResponse()
         setResponseHeader('Content-Type', 'image/jpeg')
         contentName = '%s_%s_annotation.jpg' % (
             annotation['_id'],

--- a/server/api/image.py
+++ b/server/api/image.py
@@ -24,8 +24,8 @@ from bson.errors import InvalidId
 import geojson
 
 from girder.api import access
-from girder.api.rest import Resource, RestException, loadmodel, rawResponse, \
-    setResponseHeader
+from girder.api.rest import Resource, RestException, loadmodel, \
+    setRawResponse, setResponseHeader
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType
 from girder.models.model_base import GirderException
@@ -155,7 +155,6 @@ class ImageResource(Resource):
     )
     @access.cookie
     @access.public
-    @rawResponse
     @loadmodel(model='image', plugin='isic_archive', level=AccessType.READ)
     def thumbnail(self, image, params):
         width = int(params.get('width', 256))
@@ -163,6 +162,9 @@ class ImageResource(Resource):
         thumbData, thumbMime = self.model('image_item', 'large_image')\
             .getThumbnail(image, width=width)
 
+        # Only setRawResponse now, as this handler may return a JSON error
+        # earlier
+        setRawResponse()
         setResponseHeader('Content-Type', thumbMime)
         return thumbData
 

--- a/server/api/segmentation.py
+++ b/server/api/segmentation.py
@@ -24,8 +24,8 @@ import numpy
 import six
 
 from girder.api import access
-from girder.api.rest import Resource, RestException, loadmodel, rawResponse, \
-    setResponseHeader
+from girder.api.rest import Resource, RestException, loadmodel, \
+    setRawResponse, setResponseHeader
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType, SortDir
 
@@ -233,7 +233,6 @@ class SegmentationResource(Resource):
     )
     @access.cookie
     @access.public
-    @rawResponse
     @loadmodel(model='segmentation', plugin='isic_archive')
     def mask(self, segmentation, params):
         File = self.model('file')
@@ -255,9 +254,8 @@ class SegmentationResource(Resource):
             raise RestException(
                 'This segmentation is failed, and thus has no mask.', code=410)
 
-        maskStream = File.download(
+        return File.download(
             maskFile, headers=True, contentDisposition=contentDisp)
-        return maskStream
 
     @describeRoute(
         Description('Get a segmentation, rendered as a thumbnail with a '
@@ -272,7 +270,6 @@ class SegmentationResource(Resource):
     )
     @access.cookie
     @access.public
-    @rawResponse
     @loadmodel(model='segmentation', plugin='isic_archive')
     def thumbnail(self, segmentation, params):
         Image = self.model('image', 'isic_archive')
@@ -298,6 +295,9 @@ class SegmentationResource(Resource):
                 code=410)
         thumbnailImageData = thumbnailImageStream.getvalue()
 
+        # Only setRawResponse now, as this handler may return a JSON error
+        # earlier
+        setRawResponse()
         setResponseHeader('Content-Type', 'image/jpeg')
         contentName = '%s_segmentation_thumbnail.jpg' % image['name']
         if contentDisp == 'inline':


### PR DESCRIPTION
This prevents thrown JSON errors being interpreted as raw responses.