### PR TITLE
Allow publicly-accessable GET endpoints to be authenticated by cookie

### DIFF
--- a/server/api/annotation.py
+++ b/server/api/annotation.py
@@ -49,6 +49,7 @@ class AnnotationResource(IsicResource):
                paramType='query', required=False)
         .errorResponse()
     )
+    @access.cookie
     @access.public
     def find(self, params):
         Annotation = self.model('annotation', 'isic_archive')
@@ -100,6 +101,7 @@ class AnnotationResource(IsicResource):
                paramType='path')
         .errorResponse()
     )
+    @access.cookie
     @access.public
     @loadmodel(model='annotation', plugin='isic_archive', level=AccessType.READ)
     def getAnnotation(self, annotation, params):

--- a/server/api/dataset.py
+++ b/server/api/dataset.py
@@ -57,6 +57,7 @@ class DatasetResource(IsicResource):
         .pagingParams(defaultSort='name')
         .errorResponse()
     )
+    @access.cookie
     @access.public
     def find(self, params):
         Dataset = self.model('dataset', 'isic_archive')
@@ -80,6 +81,7 @@ class DatasetResource(IsicResource):
         .param('id', 'The ID of the dataset.', paramType='path')
         .errorResponse('ID was invalid.')
     )
+    @access.cookie
     @access.public
     @loadmodel(model='dataset', plugin='isic_archive', level=AccessType.READ)
     def getDataset(self, dataset, params):

--- a/server/api/featureset.py
+++ b/server/api/featureset.py
@@ -40,6 +40,7 @@ class FeaturesetResource(IsicResource):
         .pagingParams(defaultSort='name')
         .responseClass('Featureset')
     )
+    @access.cookie
     @access.public
     def find(self, params):
         Featureset = self.model('featureset', 'isic_archive')
@@ -75,6 +76,7 @@ class FeaturesetResource(IsicResource):
         .param('id', 'The ID of the featureset.', paramType='path')
         .errorResponse('ID was invalid.')
     )
+    @access.cookie
     @access.public
     @loadmodel(model='featureset', plugin='isic_archive')
     def getFeatureset(self, featureset, params):

--- a/server/api/image.py
+++ b/server/api/image.py
@@ -59,6 +59,7 @@ class ImageResource(IsicResource):
                required=False)
         .errorResponse()
     )
+    @access.cookie
     @access.public
     def find(self, params):
         Image = self.model('image', 'isic_archive')
@@ -100,6 +101,7 @@ class ImageResource(IsicResource):
                required=False)
         .errorResponse()
     )
+    @access.cookie
     @access.public
     def getHistogram(self, params):
         Image = self.model('image', 'isic_archive')
@@ -115,6 +117,7 @@ class ImageResource(IsicResource):
         .param('id', 'The ID of the image.', paramType='path')
         .errorResponse('ID was invalid.')
     )
+    @access.cookie
     @access.public
     @loadmodel(model='image', plugin='isic_archive', level=AccessType.READ)
     def getImage(self, image, params):

--- a/server/api/segmentation.py
+++ b/server/api/segmentation.py
@@ -53,6 +53,7 @@ class SegmentationResource(IsicResource):
         .param('creatorId', 'The ID of the creator user.', required=False)
         .errorResponse('ID was invalid.')
     )
+    @access.cookie
     @access.public
     def find(self, params):
         Image = self.model('image', 'isic_archive')
@@ -203,6 +204,7 @@ class SegmentationResource(IsicResource):
         .param('id', 'The ID of the segmentation.', paramType='path')
         .errorResponse('ID was invalid.')
     )
+    @access.cookie
     @access.public
     @loadmodel(model='segmentation', plugin='isic_archive')
     def getSegmentation(self, segmentation, params):

--- a/server/api/study.py
+++ b/server/api/study.py
@@ -54,6 +54,7 @@ class StudyResource(IsicResource):
                paramType='query', required=False)
         .errorResponse()
     )
+    @access.cookie
     @access.public
     def find(self, params):
         Study = self.model('study', 'isic_archive')
@@ -100,6 +101,7 @@ class StudyResource(IsicResource):
                default='json')
         .errorResponse()
     )
+    @access.cookie
     @access.public
     @loadmodel(model='study', plugin='isic_archive', level=AccessType.READ)
     def getStudy(self, study, params):


### PR DESCRIPTION
This permits client code running from CORS-authorized non-same-origin domains to issue cookie-authenticated requests to fetch ISIC Archive data. Other origins cannot (and should not) ever be permitted to read the ISIC Archive cookie, so the Girder-Token header cannot be set.

Deployed ISIC Archive instances must be judicious about which domains are allowed to do CORS, as any authorized instances could now fetch and leak private data.