### PR TITLE
Upgrade Girder to v1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
             - p7zip-full
 
 before_install:
-    - GIRDER_VERSION=a24de8e4643fdaba227144dbdcaa6bb1866158f5
+    - GIRDER_VERSION=v1.7.0
     - WORKER_VERSION=2cfb739c096c2373f8bbe00853e3709f433192a6
     - LARGE_IMAGE_VERSION=60c32b11abb4d5f0d1696221a7e81ab21c611980
     - export MONGO_VERSION=3.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,6 @@ before_install:
     - rm -fr $girder_path
     - git clone https://github.com/girder/girder.git $girder_path && git -C $girder_path checkout $GIRDER_VERSION
     - ln -s $main_path $girder_path/plugins/isic_archive
-    # Backport a fix from https://github.com/girder/girder/pull/1596
-    - sed -i 's/"grunt-shell":\ ">=0.2.1"/"grunt-shell":\ "1.3.1"/' $girder_path/package.json
 
     - git clone https://github.com/girder/large_image.git $girder_path/plugins/large_image && git -C $girder_path/plugins/large_image checkout $LARGE_IMAGE_VERSION
 

--- a/ansible/roles/girder/templates/girder.local.cfg.j2
+++ b/ansible/roles/girder/templates/girder.local.cfg.j2
@@ -1,7 +1,7 @@
 [global]
-server.socket_host: "127.0.0.1"
-server.socket_port: {{ girder_port }}
-tools.proxy.on: True
+server.socket_host = "127.0.0.1"
+server.socket_port = {{ girder_port }}
+tools.proxy.on = True
 
 [server]
-mode: "development"
+mode = "development"

--- a/ansible/roles/isic/vars/main.yml
+++ b/ansible/roles/isic/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 
-girder_version: "a24de8e4643fdaba227144dbdcaa6bb1866158f5"
+girder_version: "v1.7.0"
 worker_version: "2cfb739c096c2373f8bbe00853e3709f433192a6"
 python_dist: "conda"
 python_dist_path: "{{ ansible_user_dir }}/env"

--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -29,6 +29,5 @@ from .study import StudyResource
 from .task import TaskResource
 from .user import attachUserApi
 
-__all__ = [AnnotationResource, DatasetResource, FeaturesetResource,
-           ImageResource, SegmentationResource, StudyResource, TaskResource,
-           attachUserApi]
+__all__ = [AnnotationResource, DatasetResource, FeaturesetResource, ImageResource,
+           SegmentationResource, StudyResource, TaskResource, attachUserApi]

--- a/server/api/annotation.py
+++ b/server/api/annotation.py
@@ -23,6 +23,7 @@ from girder.api import access
 from girder.api.rest import RestException, loadmodel, setRawResponse, setResponseHeader
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType
+from girder.models.model_base import ValidationException
 
 from .base import IsicResource
 from ..models.segmentation_helpers import ScikitSegmentationHelper
@@ -153,7 +154,8 @@ class AnnotationResource(IsicResource):
         Annotation = self.model('annotation', 'isic_archive')
         contentDisp = params.get('contentDisposition', None)
         if contentDisp is not None and contentDisp not in {'inline', 'attachment'}:
-            raise RestException('Unallowed contentDisposition type "%s".' % contentDisp)
+            raise ValidationException('Unallowed contentDisposition type "%s".' % contentDisp,
+                                      'contentDisposition')
 
         self.requireParams(['featureId'], params)
         featureId = params['featureId']
@@ -162,7 +164,7 @@ class AnnotationResource(IsicResource):
         featureset = Study.getFeatureset(study)
 
         if not any(featureId == feature['id'] for feature in featureset['localFeatures']):
-            raise RestException('Invalid featureId.')
+            raise ValidationException('Invalid featureId.', 'featureId')
         if Annotation.getState(annotation) != Study.State.COMPLETE:
             raise RestException('Only complete annotations can be rendered.')
 

--- a/server/api/annotation.py
+++ b/server/api/annotation.py
@@ -20,8 +20,7 @@
 import datetime
 
 from girder.api import access
-from girder.api.rest import RestException, loadmodel, setRawResponse, \
-    setResponseHeader
+from girder.api.rest import RestException, loadmodel, setRawResponse, setResponseHeader
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType
 
@@ -41,12 +40,9 @@ class AnnotationResource(IsicResource):
 
     @describeRoute(
         Description('Return a list of annotations.')
-        .param('studyId', 'The ID of the study to filter by.',
-               paramType='query', required=True)
-        .param('userId', 'The ID of the user to filter by.',
-               paramType='query', required=False)
-        .param('imageId', 'The ID of the image to filter by.',
-               paramType='query', required=False)
+        .param('studyId', 'The ID of the study to filter by.', paramType='query', required=True)
+        .param('userId', 'The ID of the user to filter by.', paramType='query', required=False)
+        .param('imageId', 'The ID of the image to filter by.', paramType='query', required=False)
         .errorResponse()
     )
     @access.cookie
@@ -97,8 +93,7 @@ class AnnotationResource(IsicResource):
 
     @describeRoute(
         Description('Get annotation details.')
-        .param('id', 'The ID of the annotation to be fetched.',
-               paramType='path')
+        .param('id', 'The ID of the annotation to be fetched.', paramType='path')
         .errorResponse()
     )
     @access.cookie
@@ -127,9 +122,7 @@ class AnnotationResource(IsicResource):
                 exc=True,
                 fields=Image.summaryFields),
             'user': User.filteredSummary(
-                user=User.load(
-                    annotation['meta']['userId'],
-                    force=True, exc=True),
+                user=User.load(annotation['meta']['userId'], force=True, exc=True),
                 accessorUser=self.getCurrentUser()),
             'state': Annotation.getState(annotation)
         }
@@ -145,14 +138,11 @@ class AnnotationResource(IsicResource):
 
     @describeRoute(
         Description('Render an annotation feature, overlaid on its image.')
-        .param('id', 'The ID of the annotation to be rendered.',
-               paramType='path')
-        .param('featureId', 'The feature ID to be rendered.',
-               paramType='query', required=True)
+        .param('id', 'The ID of the annotation to be rendered.', paramType='path')
+        .param('featureId', 'The feature ID to be rendered.', paramType='query', required=True)
         .param('contentDisposition',
-               'Specify the Content-Disposition response '
-               'header disposition-type value.', required=False,
-               enum=['inline', 'attachment'])
+               'Specify the Content-Disposition response header disposition-type value.',
+               required=False, enum=['inline', 'attachment'])
         .errorResponse()
     )
     @access.cookie
@@ -162,10 +152,8 @@ class AnnotationResource(IsicResource):
         Study = self.model('study', 'isic_archive')
         Annotation = self.model('annotation', 'isic_archive')
         contentDisp = params.get('contentDisposition', None)
-        if contentDisp is not None and \
-                contentDisp not in {'inline', 'attachment'}:
-            raise RestException('Unallowed contentDisposition type "%s".' %
-                                contentDisp)
+        if contentDisp is not None and contentDisp not in {'inline', 'attachment'}:
+            raise RestException('Unallowed contentDisposition type "%s".' % contentDisp)
 
         self.requireParams(['featureId'], params)
         featureId = params['featureId']
@@ -173,17 +161,14 @@ class AnnotationResource(IsicResource):
         study = Study.load(annotation['meta']['studyId'], force=True, exc=True)
         featureset = Study.getFeatureset(study)
 
-        if not any(featureId == feature['id']
-                   for feature in
-                   featureset['localFeatures']):
+        if not any(featureId == feature['id'] for feature in featureset['localFeatures']):
             raise RestException('Invalid featureId.')
         if Annotation.getState(annotation) != Study.State.COMPLETE:
             raise RestException('Only complete annotations can be rendered.')
 
         renderData = Annotation.renderAnnotation(annotation, featureId)
 
-        renderEncodedStream = ScikitSegmentationHelper.writeImage(
-            renderData, 'jpeg')
+        renderEncodedStream = ScikitSegmentationHelper.writeImage(renderData, 'jpeg')
         renderEncodedData = renderEncodedStream.getvalue()
 
         # Only setRawResponse now, as this handler may return a JSON error
@@ -208,8 +193,7 @@ class AnnotationResource(IsicResource):
 
     @describeRoute(
         Description('Submit a completed annotation.')
-        .param('id', 'The ID of the annotation to be submitted.',
-               paramType='path')
+        .param('id', 'The ID of the annotation to be submitted.', paramType='path')
         .param('body', 'JSON containing the annotation parameters.',
                paramType='body', required=True)
         .errorResponse()
@@ -221,8 +205,7 @@ class AnnotationResource(IsicResource):
         Study = self.model('study', 'isic_archive')
 
         if annotation['baseParentId'] != Study.loadStudyCollection()['_id']:
-            raise RestException(
-                'Annotation id references a non-annotation item.')
+            raise RestException('Annotation id references a non-annotation item.')
 
         if annotation['meta']['userId'] != self.getCurrentUser()['_id']:
             raise RestException('Current user does not own this annotation.')
@@ -231,14 +214,13 @@ class AnnotationResource(IsicResource):
             raise RestException('Annotation is already complete.')
 
         bodyJson = self.getBodyJson()
-        self.requireParams(['status', 'startTime', 'stopTime', 'annotations'],
-                           bodyJson)
+        self.requireParams(['status', 'startTime', 'stopTime', 'annotations'], bodyJson)
 
         annotation['meta']['status'] = bodyJson['status']
-        annotation['meta']['startTime'] = \
-            datetime.datetime.utcfromtimestamp(bodyJson['startTime'] / 1000.0)
-        annotation['meta']['stopTime'] = \
-            datetime.datetime.utcfromtimestamp(bodyJson['stopTime'] / 1000.0)
+        annotation['meta']['startTime'] = datetime.datetime.utcfromtimestamp(
+            bodyJson['startTime'] / 1000.0)
+        annotation['meta']['stopTime'] = datetime.datetime.utcfromtimestamp(
+            bodyJson['stopTime'] / 1000.0)
         annotation['meta']['annotations'] = bodyJson['annotations']
 
         Annotation.save(annotation)

--- a/server/api/base.py
+++ b/server/api/base.py
@@ -35,8 +35,7 @@ class IsicResource(Resource):
         :return: The decoded parameters.
         :rtype: dict
         """
-        if cherrypy.request.headers['Content-Type'].split(';')[0] == \
-                'application/json':
+        if cherrypy.request.headers['Content-Type'].split(';')[0] == 'application/json':
             decodedParams = self.getBodyJson()
         else:
             decodedParams = {}

--- a/server/api/featureset.py
+++ b/server/api/featureset.py
@@ -89,9 +89,7 @@ class FeaturesetResource(IsicResource):
         output = Featureset.filter(featureset)
 
         output['creator'] = User.filteredSummary(
-            User.load(
-                output.pop('creatorId'),
-                force=True, exc=True),
+            User.load(output.pop('creatorId'), force=True, exc=True),
             self.getCurrentUser())
 
         return output
@@ -99,13 +97,10 @@ class FeaturesetResource(IsicResource):
     @describeRoute(
         Description('Create a featureset.')
         .param('name', 'The name of the featureset.', paramType='form')
-        .param('version', 'The numeric version of the featureset.',
+        .param('version', 'The numeric version of the featureset.', paramType='form')
+        .param('globalFeatures', 'The global features of the featureset, as a JSON array.',
                paramType='form')
-        .param('globalFeatures',
-               'The global features of the featureset, as a JSON array.',
-               paramType='form')
-        .param('localFeatures',
-               'The local features of the featureset, as a JSON array.',
+        .param('localFeatures', 'The local features of the featureset, as a JSON array.',
                paramType='form')
     )
     @access.user
@@ -118,9 +113,7 @@ class FeaturesetResource(IsicResource):
         User.requireAdminStudy(creatorUser)
 
         params = self._decodeParams(params)
-        self.requireParams(
-            ['name', 'version', 'globalFeatures', 'localFeatures'],
-            params)
+        self.requireParams(['name', 'version', 'globalFeatures', 'localFeatures'], params)
 
         featuresetName = params['name'].strip()
         if not featuresetName:
@@ -161,8 +154,7 @@ class FeaturesetResource(IsicResource):
         User.requireAdminStudy(user)
 
         if Study.find({'meta.featuresetId': featureset['_id']}).count():
-            raise RestException(
-                'Featureset is in use by one or more studies.', 409)
+            raise RestException('Featureset is in use by one or more studies.', 409)
 
         Featureset.remove(featureset)
 

--- a/server/api/image.py
+++ b/server/api/image.py
@@ -26,8 +26,7 @@ import geojson
 import six
 
 from girder.api import access
-from girder.api.rest import RestException, loadmodel, setRawResponse, \
-    setResponseHeader
+from girder.api.rest import RestException, loadmodel, setRawResponse, setResponseHeader
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType
 from girder.models.model_base import GirderException, ValidationException
@@ -57,22 +56,19 @@ class ImageResource(IsicResource):
             try:
                 filterParam = json.loads(filterParam)
             except ValueError as e:
-                raise ValidationException(
-                    'Could not decode JSON: %s' % str(e), 'filter')
+                raise ValidationException('Could not decode JSON: %s' % str(e), 'filter')
         try:
             return querylang.astToMongo(filterParam)
         except (TypeError, ValueError) as e:
-            raise ValidationException(
-                'Could not parse filter:' % str(e), 'filter')
+            raise ValidationException('Could not parse filter:' % str(e), 'filter')
 
     @describeRoute(
         Description('Return a list of lesion images.')
         .pagingParams(defaultSort='name')
         .param('datasetId', 'The ID of the dataset to use.', required=False)
-        .param('name', 'Find an image with a specific name.',
-               required=False)
-        .param('filter', 'Filter the images by a PegJS-specified grammar '
-                         '(causing "datasetId" and "name" to be ignored).',
+        .param('name', 'Find an image with a specific name.', required=False)
+        .param('filter', 'Filter the images by a PegJS-specified grammar (causing "datasetId" and '
+                         '"name" to be ignored).',
                required=False)
         .errorResponse()
     )
@@ -92,8 +88,7 @@ class ImageResource(IsicResource):
                 try:
                     query.update({'folderId': ObjectId(params['datasetId'])})
                 except InvalidId:
-                    raise RestException(
-                        'Invalid "folderId" ObjectId: %s' % params['datasetId'])
+                    raise RestException('Invalid "folderId" ObjectId: %s' % params['datasetId'])
             if 'name' in params:
                 query.update({'name': params['name']})
 
@@ -112,10 +107,9 @@ class ImageResource(IsicResource):
 
     @describeRoute(
         Description('Download multiple images as a ZIP file.')
-        .param('datasetId', 'The ID of the dataset to download.',
-               required=False)
-        .param('filter', 'Filter the images by a PegJS-specified grammar '
-                         '(causing "datasetId" to be ignored).',
+        .param('datasetId', 'The ID of the dataset to download.', required=False)
+        .param('filter', 'Filter the images by a PegJS-specified grammar (causing "datasetId" to '
+                         'be ignored).',
                required=False)
         .errorResponse()
     )
@@ -134,8 +128,7 @@ class ImageResource(IsicResource):
                 try:
                     query.update({'folderId': ObjectId(params['datasetId'])})
                 except InvalidId:
-                    raise RestException(
-                        'Invalid "folderId" ObjectId: %s' % params['datasetId'])
+                    raise RestException('Invalid "folderId" ObjectId: %s' % params['datasetId'])
 
         user = self.getCurrentUser()
         downloadFileName = 'ISIC-images'
@@ -150,8 +143,7 @@ class ImageResource(IsicResource):
                     user=user, level=AccessType.READ, limit=0, offset=0):
                 datasetId = image['folderId']
                 if datasetId not in datasetCache:
-                    datasetCache[datasetId] = Dataset.load(
-                        datasetId, force=True, exc=True)
+                    datasetCache[datasetId] = Dataset.load(datasetId, force=True, exc=True)
                 dataset = datasetCache[datasetId]
                 imageFile = Image.originalFile(image)
                 imageFileGenerator = File.download(imageFile, headers=False)
@@ -184,17 +176,12 @@ class ImageResource(IsicResource):
             yield zipGenerator.footer()
 
         setResponseHeader('Content-Type', 'application/zip')
-        setResponseHeader(
-            'Content-Disposition',
-            'attachment; filename="%s.zip"' % downloadFileName)
+        setResponseHeader('Content-Disposition', 'attachment; filename="%s.zip"' % downloadFileName)
         return stream
 
     @describeRoute(
         Description('Return histograms of image metadata.')
-        .param('filter',
-               'Get the histogram after the results of this filter. ' +
-               'TODO: describe our filter grammar (an AST tree).',
-               required=False)
+        .param('filter', 'Filter the images by a PegJS-specified grammar.', required=False)
         .errorResponse()
     )
     @access.cookie
@@ -202,9 +189,7 @@ class ImageResource(IsicResource):
     def getHistogram(self, params):
         Image = self.model('image', 'isic_archive')
 
-        query = self._parseFilter(params['filter']) \
-            if 'filter' in params \
-            else None
+        query = self._parseFilter(params['filter']) if 'filter' in params else None
         user = self.getCurrentUser()
         return Image.getHistograms(query, user)
 
@@ -236,9 +221,7 @@ class ImageResource(IsicResource):
         del output['dataset']['lowerName']
 
         output['creator'] = User.filteredSummary(
-            User.load(
-                output.pop('creatorId'),
-                force=True, exc=True),
+            User.load(output.pop('creatorId'), force=True, exc=True),
             user)
 
         if User.canReviewDataset(user):
@@ -249,8 +232,8 @@ class ImageResource(IsicResource):
     @describeRoute(
         Description('Return an image\'s thumbnail.')
         .param('id', 'The ID of the image.', paramType='path')
-        .param('width', 'The desired width for the thumbnail.',
-               paramType='query', required=False, default=256)
+        .param('width', 'The desired width for the thumbnail.', paramType='query', required=False,
+               default=256)
         .errorResponse('ID was invalid.')
     )
     @access.cookie
@@ -271,9 +254,9 @@ class ImageResource(IsicResource):
     @describeRoute(
         Description('Download an image\'s high-quality original binary data.')
         .param('id', 'The ID of the image.', paramType='path')
-        .param('contentDisposition', 'Specify the Content-Disposition response '
-               'header disposition-type value.', required=False,
-               enum=['inline', 'attachment'])
+        .param('contentDisposition',
+               'Specify the Content-Disposition response header disposition-type value.',
+               required=False, enum=['inline', 'attachment'])
         .errorResponse('ID was invalid.')
     )
     @access.cookie
@@ -284,19 +267,15 @@ class ImageResource(IsicResource):
         Image = self.model('image', 'isic_archive')
 
         contentDisp = params.get('contentDisposition', None)
-        if contentDisp is not None and \
-                contentDisp not in {'inline', 'attachment'}:
-            raise RestException('Unallowed contentDisposition type "%s".' %
-                                contentDisp)
+        if contentDisp is not None and contentDisp not in {'inline', 'attachment'}:
+            raise RestException('Unallowed contentDisposition type "%s".' % contentDisp)
 
         originalFile = Image.originalFile(image)
-        fileStream = File.download(
-            originalFile, headers=True, contentDisposition=contentDisp)
+        fileStream = File.download(originalFile, headers=True, contentDisposition=contentDisp)
         return fileStream
 
     @describeRoute(
-        Description('Get the superpixels for this image, as a PNG-encoded '
-                    'label map.')
+        Description('Get the superpixels for this image, as a PNG-encoded label map.')
         .param('id', 'The ID of the image.', paramType='path')
         .errorResponse('ID was invalid.')
     )
@@ -313,11 +292,8 @@ class ImageResource(IsicResource):
     @describeRoute(
         Description('Run and return a new semi-automated segmentation.')
         .param('id', 'The ID of the image.', paramType='path')
-        .param('seed', 'The X, Y coordinates of a segmentation seed point.',
-               paramType='body')
-        .param('tolerance',
-               'The intensity tolerance value for the segmentation.',
-               paramType='body')
+        .param('seed', 'The X, Y coordinates of a segmentation seed point.', paramType='body')
+        .param('tolerance', 'The intensity tolerance value for the segmentation.', paramType='body')
         .errorResponse('ID was invalid.')
     )
     @access.user
@@ -341,8 +317,7 @@ class ImageResource(IsicResource):
             raise RestException('Submitted "tolerance" must be an integer.')
 
         try:
-            contourCoords = Segmentation.doContourSegmentation(
-                image, seedCoord, tolerance)
+            contourCoords = Segmentation.doContourSegmentation(image, seedCoord, tolerance)
         except GirderException as e:
             raise RestException(e.message)
 

--- a/server/api/image.py
+++ b/server/api/image.py
@@ -88,7 +88,7 @@ class ImageResource(IsicResource):
                 try:
                     query.update({'folderId': ObjectId(params['datasetId'])})
                 except InvalidId:
-                    raise RestException('Invalid "folderId" ObjectId: %s' % params['datasetId'])
+                    raise ValidationException('Invalid ObjectId.', 'datasetId')
             if 'name' in params:
                 query.update({'name': params['name']})
 
@@ -128,7 +128,7 @@ class ImageResource(IsicResource):
                 try:
                     query.update({'folderId': ObjectId(params['datasetId'])})
                 except InvalidId:
-                    raise RestException('Invalid "folderId" ObjectId: %s' % params['datasetId'])
+                    raise ValidationException('Invalid ObjectId.', 'datasetId')
 
         user = self.getCurrentUser()
         downloadFileName = 'ISIC-images'
@@ -268,7 +268,8 @@ class ImageResource(IsicResource):
 
         contentDisp = params.get('contentDisposition', None)
         if contentDisp is not None and contentDisp not in {'inline', 'attachment'}:
-            raise RestException('Unallowed contentDisposition type "%s".' % contentDisp)
+            raise ValidationException('Unallowed contentDisposition type "%s".' % contentDisp,
+                                      'contentDisposition')
 
         originalFile = Image.originalFile(image)
         fileStream = File.download(originalFile, headers=True, contentDisposition=contentDisp)
@@ -310,11 +311,11 @@ class ImageResource(IsicResource):
             len(seedCoord) == 2 and
             all(isinstance(value, int) for value in seedCoord)
         ):
-            raise RestException('Submitted "seed" must be a coordinate pair.')
+            raise ValidationException('Value must be a coordinate pair.', 'seed')
 
         tolerance = params['tolerance']
         if not isinstance(tolerance, int):
-            raise RestException('Submitted "tolerance" must be an integer.')
+            raise ValidationException('Value must be an integer.', 'tolerance')
 
         try:
             contourCoords = Segmentation.doContourSegmentation(image, seedCoord, tolerance)

--- a/server/api/segmentation.py
+++ b/server/api/segmentation.py
@@ -24,14 +24,12 @@ import numpy
 import six
 
 from girder.api import access
-from girder.api.rest import RestException, loadmodel, setRawResponse, \
-    setResponseHeader
+from girder.api.rest import RestException, loadmodel, setRawResponse, setResponseHeader
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType, SortDir
 
 from .base import IsicResource
-from ..models.segmentation_helpers import OpenCVSegmentationHelper, \
-    ScikitSegmentationHelper
+from ..models.segmentation_helpers import OpenCVSegmentationHelper, ScikitSegmentationHelper
 
 
 class SegmentationResource(IsicResource):
@@ -62,12 +60,10 @@ class SegmentationResource(IsicResource):
 
         self.requireParams(['imageId'], params)
         limit, offset, sort = self.getPagingParameters(
-            params,
-            defaultSortField='created', defaultSortDir=SortDir.DESCENDING)
+            params, defaultSortField='created', defaultSortDir=SortDir.DESCENDING)
 
         image = Image.load(
-            params['imageId'], level=AccessType.READ,
-            user=self.getCurrentUser(), exc=True)
+            params['imageId'], level=AccessType.READ, user=self.getCurrentUser(), exc=True)
 
         filters = {
             'imageId': image['_id']
@@ -101,10 +97,9 @@ class SegmentationResource(IsicResource):
     @describeRoute(
         Description('Add a segmentation to an image.')
         .param('imageId', 'The ID of the image.', paramType='body')
-        .param('mask', 'A Base64-encoded PNG 8-bit image, containing the '
-                       'segmentation mask.', paramType='body')
-        .param('failed',
-               'Whether the segmentation should be marked as a failure.',
+        .param('mask', 'A Base64-encoded PNG 8-bit image, containing the segmentation mask.',
+               paramType='body')
+        .param('failed', 'Whether the segmentation should be marked as a failure.',
                paramType='body', dataType='boolean', required=False)
         .errorResponse('ID was invalid.')
     )
@@ -120,8 +115,7 @@ class SegmentationResource(IsicResource):
         user = self.getCurrentUser()
         User.requireSegmentationSkill(user)
 
-        image = Image.load(
-            params['imageId'], level=AccessType.READ, user=user, exc=True)
+        image = Image.load(params['imageId'], level=AccessType.READ, user=user, exc=True)
 
         failed = self.boolParam('failed', params)
 
@@ -138,10 +132,8 @@ class SegmentationResource(IsicResource):
             lesionBoundary = params['lesionBoundary']
 
             meta = lesionBoundary['properties']
-            meta['startTime'] = datetime.datetime.utcfromtimestamp(
-                meta['startTime'] / 1000.0),
-            meta['stopTime'] = datetime.datetime.utcfromtimestamp(
-                meta['stopTime'] / 1000.0)
+            meta['startTime'] = datetime.datetime.utcfromtimestamp(meta['startTime'] / 1000.0),
+            meta['stopTime'] = datetime.datetime.utcfromtimestamp(meta['stopTime'] / 1000.0)
 
             if meta.get('source') == 'autofill':
                 # Since converting an autofill coordinate list back to a mask
@@ -155,13 +147,11 @@ class SegmentationResource(IsicResource):
                     len(seedCoord) == 2 and
                     all(isinstance(value, int) for value in seedCoord)
                 ):
-                    raise RestException(
-                        'Submitted "seed" must be a coordinate pair.')
+                    raise RestException('Submitted "seed" must be a coordinate pair.')
 
                 tolerance = meta['tolerance']
                 if not isinstance(tolerance, int):
-                    raise RestException(
-                        'Submitted "tolerance" must be an integer.')
+                    raise RestException('Submitted "tolerance" must be an integer.')
 
                 mask = Segmentation.doSegmentation(image, seedCoord, tolerance)
             else:
@@ -192,8 +182,7 @@ class SegmentationResource(IsicResource):
                 meta={}
             )
         else:
-            raise RestException(
-                'One of "failed", "lesionBoundary", or "mask" must be present')
+            raise RestException('One of "failed", "lesionBoundary", or "mask" must be present')
 
         # TODO: return 201?
         # TODO: remove maskId from return?
@@ -213,13 +202,10 @@ class SegmentationResource(IsicResource):
 
         # TODO: convert this to make Segmentation use an AccessControlMixin
         Image.load(
-            segmentation['imageId'], level=AccessType.READ,
-            user=self.getCurrentUser(), exc=True)
+            segmentation['imageId'], level=AccessType.READ, user=self.getCurrentUser(), exc=True)
 
         segmentation['creator'] = User.filteredSummary(
-            User.load(
-                segmentation.pop('creatorId'),
-                force=True, exc=True),
+            User.load(segmentation.pop('creatorId'), force=True, exc=True),
             self.getCurrentUser())
 
         segmentation['failed'] = segmentation.pop('maskId') is None
@@ -229,9 +215,9 @@ class SegmentationResource(IsicResource):
     @describeRoute(
         Description('Get a segmentation, rendered as a binary mask.')
         .param('id', 'The ID of the segmentation.', paramType='path')
-        .param('contentDisposition', 'Specify the Content-Disposition response '
-               'header disposition-type value.', required=False,
-               enum=['inline', 'attachment'])
+        .param('contentDisposition',
+               'Specify the Content-Disposition response header disposition-type value.',
+               required=False, enum=['inline', 'attachment'])
         .errorResponse('ID was invalid.')
     )
     @access.cookie
@@ -242,33 +228,27 @@ class SegmentationResource(IsicResource):
         Image = self.model('image', 'isic_archive')
         Segmentation = self.model('segmentation', 'isic_archive')
         contentDisp = params.get('contentDisposition', None)
-        if contentDisp is not None and \
-                contentDisp not in {'inline', 'attachment'}:
-            raise RestException('Unallowed contentDisposition type "%s".' %
-                                contentDisp)
+        if contentDisp is not None and contentDisp not in {'inline', 'attachment'}:
+            raise RestException('Unallowed contentDisposition type "%s".' % contentDisp)
 
         # TODO: convert this to make Segmentation use an AccessControlMixin
         Image.load(
-            segmentation['imageId'], level=AccessType.READ,
-            user=self.getCurrentUser(), exc=True)
+            segmentation['imageId'], level=AccessType.READ, user=self.getCurrentUser(), exc=True)
 
         maskFile = Segmentation.maskFile(segmentation)
         if maskFile is None:
-            raise RestException(
-                'This segmentation is failed, and thus has no mask.', code=410)
+            raise RestException('This segmentation is failed, and thus has no mask.', code=410)
 
-        return File.download(
-            maskFile, headers=True, contentDisposition=contentDisp)
+        return File.download(maskFile, headers=True, contentDisposition=contentDisp)
 
     @describeRoute(
-        Description('Get a segmentation, rendered as a thumbnail with a '
-                    'boundary overlay.')
+        Description('Get a segmentation, rendered as a thumbnail with a boundary overlay.')
         .param('id', 'The ID of the segmentation.', paramType='path')
-        .param('width', 'The desired width for the thumbnail.',
-               paramType='query', required=False, default=256)
-        .param('contentDisposition', 'Specify the Content-Disposition response '
-               'header disposition-type value.', required=False,
-               enum=['inline', 'attachment'])
+        .param('width', 'The desired width for the thumbnail.', paramType='query', required=False,
+               default=256)
+        .param('contentDisposition',
+               'Specify the Content-Disposition response header disposition-type value.',
+               required=False, enum=['inline', 'attachment'])
         .errorResponse('ID was invalid.')
     )
     @access.cookie
@@ -278,24 +258,18 @@ class SegmentationResource(IsicResource):
         Image = self.model('image', 'isic_archive')
         Segmentation = self.model('segmentation', 'isic_archive')
         contentDisp = params.get('contentDisposition', None)
-        if contentDisp is not None and \
-                contentDisp not in {'inline', 'attachment'}:
-            raise RestException('Unallowed contentDisposition type "%s".' %
-                                contentDisp)
+        if contentDisp is not None and contentDisp not in {'inline', 'attachment'}:
+            raise RestException('Unallowed contentDisposition type "%s".' % contentDisp)
 
         # TODO: convert this to make Segmentation use an AccessControlMixin
         image = Image.load(
-            segmentation['imageId'], level=AccessType.READ,
-            user=self.getCurrentUser(), exc=True)
+            segmentation['imageId'], level=AccessType.READ, user=self.getCurrentUser(), exc=True)
 
         width = int(params.get('width', 256))
 
-        thumbnailImageStream = Segmentation.boundaryThumbnail(
-            segmentation, image, width)
+        thumbnailImageStream = Segmentation.boundaryThumbnail(segmentation, image, width)
         if thumbnailImageStream is None:
-            raise RestException(
-                'This segmentation is failed, and thus has no thumbnail.',
-                code=410)
+            raise RestException('This segmentation is failed, and thus has no thumbnail.', code=410)
         thumbnailImageData = thumbnailImageStream.getvalue()
 
         # Only setRawResponse now, as this handler may return a JSON error
@@ -304,13 +278,9 @@ class SegmentationResource(IsicResource):
         setResponseHeader('Content-Type', 'image/jpeg')
         contentName = '%s_segmentation_thumbnail.jpg' % image['name']
         if contentDisp == 'inline':
-            setResponseHeader(
-                'Content-Disposition',
-                'inline; filename="%s"' % contentName)
+            setResponseHeader('Content-Disposition', 'inline; filename="%s"' % contentName)
         else:
-            setResponseHeader(
-                'Content-Disposition',
-                'attachment; filename="%s"' % contentName)
+            setResponseHeader('Content-Disposition', 'attachment; filename="%s"' % contentName)
         setResponseHeader('Content-Length', len(thumbnailImageData))
 
         return thumbnailImageData
@@ -318,8 +288,8 @@ class SegmentationResource(IsicResource):
     @describeRoute(
         Description('Review a segmentation.')
         .param('id', 'The ID of the segmentation.', paramType='path')
-        .param('approved', 'Whether the segmentation was approved by the user.',
-               paramType='body', dataType='boolean')
+        .param('approved', 'Whether the segmentation was approved by the user.', paramType='body',
+               dataType='boolean')
         .errorResponse('ID was invalid.')
     )
     @access.user

--- a/server/api/segmentation.py
+++ b/server/api/segmentation.py
@@ -27,6 +27,7 @@ from girder.api import access
 from girder.api.rest import RestException, loadmodel, setRawResponse, setResponseHeader
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType, SortDir
+from girder.models.model_base import ValidationException
 
 from .base import IsicResource
 from ..models.segmentation_helpers import OpenCVSegmentationHelper, ScikitSegmentationHelper
@@ -147,11 +148,11 @@ class SegmentationResource(IsicResource):
                     len(seedCoord) == 2 and
                     all(isinstance(value, int) for value in seedCoord)
                 ):
-                    raise RestException('Submitted "seed" must be a coordinate pair.')
+                    raise ValidationException('Value must be a coordinate pair.', 'seedPoint')
 
                 tolerance = meta['tolerance']
                 if not isinstance(tolerance, int):
-                    raise RestException('Submitted "tolerance" must be an integer.')
+                    raise ValidationException('Value must be an integer.', 'tolerance')
 
                 mask = Segmentation.doSegmentation(image, seedCoord, tolerance)
             else:
@@ -229,7 +230,8 @@ class SegmentationResource(IsicResource):
         Segmentation = self.model('segmentation', 'isic_archive')
         contentDisp = params.get('contentDisposition', None)
         if contentDisp is not None and contentDisp not in {'inline', 'attachment'}:
-            raise RestException('Unallowed contentDisposition type "%s".' % contentDisp)
+            raise ValidationException('Unallowed contentDisposition type "%s".' % contentDisp,
+                                      'contentDisposition')
 
         # TODO: convert this to make Segmentation use an AccessControlMixin
         Image.load(
@@ -259,7 +261,8 @@ class SegmentationResource(IsicResource):
         Segmentation = self.model('segmentation', 'isic_archive')
         contentDisp = params.get('contentDisposition', None)
         if contentDisp is not None and contentDisp not in {'inline', 'attachment'}:
-            raise RestException('Unallowed contentDisposition type "%s".' % contentDisp)
+            raise ValidationException('Unallowed contentDisposition type "%s".' % contentDisp,
+                                      'contentDisposition')
 
         # TODO: convert this to make Segmentation use an AccessControlMixin
         image = Image.load(

--- a/server/api/study.py
+++ b/server/api/study.py
@@ -74,7 +74,7 @@ class StudyResource(IsicResource):
         if params.get('state'):
             state = params['state']
             if state not in {Study.State.ACTIVE, Study.State.COMPLETE}:
-                raise RestException('Query parameter "state" may only be "active" or "complete".')
+                raise ValidationException('Value may only be "active" or "complete".', 'state')
 
         return [
             {
@@ -263,14 +263,14 @@ class StudyResource(IsicResource):
         featureset = Featureset.load(featuresetId, exc=True)
 
         if len(set(params['userIds'])) != len(params['userIds']):
-            raise RestException('Duplicate user IDs.')
+            raise ValidationException('Duplicate user IDs.', 'userIds')
         annotatorUsers = [
             User.load(annotatorUserId, user=creatorUser, level=AccessType.READ, exc=True)
             for annotatorUserId in params['userIds']
         ]
 
         if len(set(params['imageIds'])) != len(params['imageIds']):
-            raise RestException('Duplicate image IDs.')
+            raise ValidationException('Duplicate image IDs.', 'imageIds')
         images = [
             Image.load(imageId, user=creatorUser, level=AccessType.READ, exc=True)
             for imageId in params['imageIds']
@@ -309,7 +309,7 @@ class StudyResource(IsicResource):
 
         # Load all users before adding any, to ensure all are valid
         if len(set(params['userIds'])) != len(params['userIds']):
-            raise RestException('Duplicate user IDs.')
+            raise ValidationException('Duplicate user IDs.', 'userIds')
         annotatorUsers = [
             User.load(userId, user=creatorUser, level=AccessType.READ, exc=True)
             for userId in params['userIds']
@@ -358,7 +358,7 @@ class StudyResource(IsicResource):
         # Load all images before adding any, to ensure all are valid and
         # accessible
         if len(set(params['imageIds'])) != len(params['imageIds']):
-            raise RestException('Duplicate image IDs.')
+            raise ValidationException('Duplicate image IDs.', 'imageIds')
         images = [
             Image.load(imageId, user=creatorUser, level=AccessType.READ, exc=True)
             for imageId in params['imageIds']

--- a/server/api/study.py
+++ b/server/api/study.py
@@ -49,10 +49,9 @@ class StudyResource(IsicResource):
     @describeRoute(
         Description('Return a list of annotation studies.')
         .pagingParams(defaultSort='lowerName')
-        .param('state', 'Filter studies to those at a given state',
-               paramType='query', required=False, enum=('active', 'complete'))
-        .param('userId',
-               'Filter studies to those containing a user ID, or "me".',
+        .param('state', 'Filter studies to those at a given state', paramType='query',
+               required=False, enum=('active', 'complete'))
+        .param('userId', 'Filter studies to those containing a user ID, or "me".',
                paramType='query', required=False)
         .errorResponse()
     )
@@ -69,16 +68,13 @@ class StudyResource(IsicResource):
             if params['userId'] == 'me':
                 annotatorUser = self.getCurrentUser()
             else:
-                annotatorUser = User.load(
-                    id=params['userId'],
-                    force=True, exc=True)
+                annotatorUser = User.load(params['userId'], force=True, exc=True)
 
         state = None
         if params.get('state'):
             state = params['state']
             if state not in {Study.State.ACTIVE, Study.State.COMPLETE}:
-                raise RestException('Query parameter "state" may only '
-                                    'be "active" or "complete".')
+                raise RestException('Query parameter "state" may only be "active" or "complete".')
 
         return [
             {
@@ -88,19 +84,16 @@ class StudyResource(IsicResource):
             }
             for study in
             Study.filterResultsByPermission(
-                Study.find(query=None, annotatorUser=annotatorUser,
-                           state=state, sort=sort),
-                user=self.getCurrentUser(),
-                level=AccessType.READ, limit=limit, offset=offset
+                Study.find(query=None, annotatorUser=annotatorUser, state=state, sort=sort),
+                user=self.getCurrentUser(), level=AccessType.READ, limit=limit, offset=offset
             )
         ]
 
     @describeRoute(
         Description('Get a study by ID.')
         .param('id', 'The ID of the study.', paramType='path')
-        .param('format', 'The output format.',
-               paramType='query', required=False, enum=('csv', 'json'),
-               default='json')
+        .param('format', 'The output format.', paramType='query', required=False,
+               enum=('csv', 'json'), default='json')
         .errorResponse()
     )
     @access.cookie
@@ -114,9 +107,8 @@ class StudyResource(IsicResource):
 
         if params.get('format') == 'csv':
             setResponseHeader('Content-Type', 'text/csv')
-            setResponseHeader(
-                'Content-Disposition',
-                'attachment; filename="%s.csv"' % study['name'])
+            setResponseHeader('Content-Disposition',
+                              'attachment; filename="%s.csv"' % study['name'])
             return functools.partial(self._getStudyCSVStream, study)
 
         else:
@@ -129,9 +121,7 @@ class StudyResource(IsicResource):
                     id=study['meta']['featuresetId'],
                     fields=Featureset.summaryFields, exc=True),
                 'creator': User.filteredSummary(
-                    User.load(
-                        output.pop('creatorId'),
-                        force=True, exc=True),
+                    User.load(output.pop('creatorId'), force=True, exc=True),
                     currentUser),
                 'users': sorted(
                     (
@@ -143,9 +133,8 @@ class StudyResource(IsicResource):
                     key=lambda annotatorUser: annotatorUser['name']
                 ),
                 'images': list(
-                    Study.getImages(
-                        study, Image.summaryFields
-                    ).sort('lowerName', SortDir.ASCENDING))
+                    Study.getImages(study, Image.summaryFields).sort('lowerName', SortDir.ASCENDING)
+                )
             })
 
             return output
@@ -196,8 +185,7 @@ class StudyResource(IsicResource):
                     int((annotation['meta']['stopTime'] -
                          annotation['meta']['startTime']).total_seconds())
 
-                filteredAnnotatorUser = User.filteredSummary(
-                    annotatorUser, currentUser)
+                filteredAnnotatorUser = User.filteredSummary(annotatorUser, currentUser)
                 annotatorUserName = filteredAnnotatorUser['name']
                 if 'login' in filteredAnnotatorUser:
                     annotatorUserName += ' [%s %s (%s)]' % (
@@ -220,7 +208,7 @@ class StudyResource(IsicResource):
                 for globalFeature in featureset['globalFeatures']:
                     if globalFeature['id'] in annotation['meta']['annotations']:
                         outDict[globalFeature['id']] = \
-                            annotation['meta']['annotations'][globalFeature['id']]  # noqa: E501
+                            annotation['meta']['annotations'][globalFeature['id']]
                 csvWriter.writerow(outDict)
                 yield responseBody.getvalue()
                 responseBody.seek(0)
@@ -235,7 +223,7 @@ class StudyResource(IsicResource):
                         outDict = outDictBase.copy()
                         outDict['superpixel_id'] = superpixelMum
                         for featureName, featureValue in six.viewitems(
-                                annotation['meta']['annotations']['localFeatures']):  # noqa: E501
+                                annotation['meta']['annotations']['localFeatures']):
                             outDict[featureName] = featureValue[superpixelMum]
 
                         csvWriter.writerow(outDict)
@@ -246,14 +234,10 @@ class StudyResource(IsicResource):
     @describeRoute(
         Description('Create an annotation study.')
         .param('name', 'The name of the study.', paramType='form')
-        .param('featuresetId', 'The featureset ID of the study.',
+        .param('featuresetId', 'The featureset ID of the study.', paramType='form')
+        .param('userIds', 'The annotators user IDs of the study, as a JSON array.',
                paramType='form')
-        .param('userIds',
-               'The annotators user IDs of the study, as a JSON array.',
-               paramType='form')
-        .param('imageIds',
-               'The image IDs of the study, as a JSON array.',
-               paramType='form')
+        .param('imageIds', 'The image IDs of the study, as a JSON array.', paramType='form')
         .errorResponse('Write access was denied on the parent folder.', 403)
     )
     @access.user
@@ -267,9 +251,7 @@ class StudyResource(IsicResource):
         User.requireAdminStudy(creatorUser)
 
         params = self._decodeParams(params)
-        self.requireParams(
-            ['name', 'featuresetId', 'userIds', 'imageIds'],
-            params)
+        self.requireParams(['name', 'featuresetId', 'userIds', 'imageIds'], params)
 
         studyName = params['name'].strip()
         if not studyName:
@@ -283,17 +265,14 @@ class StudyResource(IsicResource):
         if len(set(params['userIds'])) != len(params['userIds']):
             raise RestException('Duplicate user IDs.')
         annotatorUsers = [
-            User.load(
-                annotatorUserId, user=creatorUser, level=AccessType.READ,
-                exc=True)
+            User.load(annotatorUserId, user=creatorUser, level=AccessType.READ, exc=True)
             for annotatorUserId in params['userIds']
         ]
 
         if len(set(params['imageIds'])) != len(params['imageIds']):
             raise RestException('Duplicate image IDs.')
         images = [
-            Image.load(
-                imageId, user=creatorUser, level=AccessType.READ, exc=True)
+            Image.load(imageId, user=creatorUser, level=AccessType.READ, exc=True)
             for imageId in params['imageIds']
         ]
 
@@ -309,11 +288,9 @@ class StudyResource(IsicResource):
     @describeRoute(
         Description('Add annotator users to a study.')
         .param('id', 'The ID of the study.', paramType='path')
-        .param('userIds', 'The user IDs to add, as a JSON array.',
-               paramType='form')
+        .param('userIds', 'The user IDs to add, as a JSON array.', paramType='form')
         .errorResponse('ID was invalid.')
-        .errorResponse('You don\'t have permission to add a study annotator.',
-                       403)
+        .errorResponse('You don\'t have permission to add a study annotator.', 403)
     )
     @access.user
     @loadmodel(model='study', plugin='isic_archive', level=AccessType.READ)
@@ -343,15 +320,13 @@ class StudyResource(IsicResource):
         # inside yet
         duplicateAnnotatorFolders = Folder.find({
             'parentId': study['_id'],
-            'meta.userId': {'$in': [
-                annotatorUser['_id'] for annotatorUser in annotatorUsers]}
+            'meta.userId': {'$in': [annotatorUser['_id'] for annotatorUser in annotatorUsers]}
         })
         if duplicateAnnotatorFolders.count():
             # Just list the first duplicate
             duplicateAnnotatorFolder = next(iter(duplicateAnnotatorFolders))
-            raise ValidationException(
-                'Annotator user "%s" is already part of the study.' %
-                duplicateAnnotatorFolder['meta']['userId'])
+            raise ValidationException('Annotator user "%s" is already part of the study.' %
+                                      duplicateAnnotatorFolder['meta']['userId'])
         # Look up images only once for efficiency
         images = Study.getImages(study)
         for annotatorUser in annotatorUsers:
@@ -362,8 +337,7 @@ class StudyResource(IsicResource):
     @describeRoute(
         Description('Add images to a study.')
         .param('id', 'The ID of the study.', paramType='path')
-        .param('imageIds', 'The image IDs to add, as a JSON array.',
-               paramType='form')
+        .param('imageIds', 'The image IDs to add, as a JSON array.', paramType='form')
         .errorResponse('ID was invalid.')
         .errorResponse('You don\'t have permission to add a study image.', 403)
     )
@@ -386,8 +360,7 @@ class StudyResource(IsicResource):
         if len(set(params['imageIds'])) != len(params['imageIds']):
             raise RestException('Duplicate image IDs.')
         images = [
-            Image.load(
-                imageId, user=creatorUser, level=AccessType.READ, exc=True)
+            Image.load(imageId, user=creatorUser, level=AccessType.READ, exc=True)
             for imageId in params['imageIds']
         ]
         duplicateAnnotations = Annotation.find({
@@ -398,8 +371,7 @@ class StudyResource(IsicResource):
             # Just list the first duplicate
             duplicateAnnotation = next(iter(duplicateAnnotations))
             raise ValidationException(
-                'Image "%s" is already part of the study.' %
-                duplicateAnnotation['meta']['imageId'])
+                'Image "%s" is already part of the study.' % duplicateAnnotation['meta']['imageId'])
         for image in images:
             Study.addImage(study, image, creatorUser)
 
@@ -420,10 +392,8 @@ class StudyResource(IsicResource):
         # For now, study admins will be the ones that can delete studies
         User.requireAdminStudy(user)
 
-        if Study.childAnnotations(
-                study=study, state=Study.State.COMPLETE).count():
-            raise RestException(
-                'Study has completed annotations.', 409)
+        if Study.childAnnotations(study=study, state=Study.State.COMPLETE).count():
+            raise RestException('Study has completed annotations.', 409)
 
         Study.remove(study)
 

--- a/server/api/user.py
+++ b/server/api/user.py
@@ -80,9 +80,8 @@ def requestCreateDatasetPermission(params):
         group = Group.findOne({'name': groupName})
         if not group:
             raise RestException('Could not load group: %s' % groupName)
-        resp['message'] = 'Dataset Contributor access requested. An ' \
-                          'administrator may contact you via email (at %s) ' \
-                          'to process your request.' % currentUser['email']
+        resp['message'] = 'Dataset Contributor access requested. An administrator may contact ' \
+                          'you via email (at %s) to process your request.' % currentUser['email']
 
         for request in Group.getFullRequestList(group):
             if request['id'] == currentUser['_id']:
@@ -134,13 +133,9 @@ def acceptTerms(params):
 
 
 def attachUserApi(user):
-    events.bind('rest.get.user/authentication.after',
-                'onGetUserAuthentication', onGetUserAuthentication)
-    events.bind('rest.get.user/me.after',
-                'onGetUserMe', onGetUserMe)
-    events.bind('rest.post.user.after',
-                'onPostUser', onPostUser)
-    user.route('POST', ('requestCreateDatasetPermission',),
-               requestCreateDatasetPermission)
-    user.route('POST', ('acceptTerms',),
-               acceptTerms)
+    events.bind('rest.get.user/authentication.after', 'onGetUserAuthentication',
+                onGetUserAuthentication)
+    events.bind('rest.get.user/me.after', 'onGetUserMe', onGetUserMe)
+    events.bind('rest.post.user.after', 'onPostUser', onPostUser)
+    user.route('POST', ('requestCreateDatasetPermission',), requestCreateDatasetPermission)
+    user.route('POST', ('acceptTerms',), acceptTerms)

--- a/server/models/image.py
+++ b/server/models/image.py
@@ -28,7 +28,7 @@ from girder.models.item import Item as ItemModel
 from girder.plugins.worker import utils as workerUtils
 
 from . import segmentation_helpers
-from .. import constants
+from ..settings import PluginSettings
 from ..provision_utility import getAdminUser
 from .segmentation_helpers import ScikitSegmentationHelper
 
@@ -55,16 +55,14 @@ class Image(ItemModel):
         Setting = self.model('setting')
         Upload = self.model('upload')
 
-        newIsicId = Setting.get(
-            constants.PluginSettings.MAX_ISIC_ID, default=-1) + 1
+        newIsicId = Setting.get(PluginSettings.MAX_ISIC_ID) + 1
         image = self.createItem(
             name='ISIC_%07d' % newIsicId,
             creator=creator,
             folder=parentFolder,
             description=''
         )
-        Setting.set(
-            constants.PluginSettings.MAX_ISIC_ID, newIsicId)
+        Setting.set(PluginSettings.MAX_ISIC_ID, newIsicId)
 
         image['privateMeta'] = {
             'originalFilename': originalName

--- a/server/models/image.py
+++ b/server/models/image.py
@@ -230,7 +230,11 @@ class Image(ItemModel):
         File = self.model('file')
         superpixelsVersion = float(superpixelsFileNameMatch.group(1))
         superpixelsFile['superpixelVersion'] = superpixelsVersion
-        superpixelsFile = File.save(superpixelsFile)
+        # Work around an upstream Girder bug where "File.validate" sets
+        #   superpixelsFile['exts'] = ['0', 'png']
+        superpixelsFile = File.validate(superpixelsFile)
+        superpixelsFile['exts'] = ['png']
+        superpixelsFile = File.save(superpixelsFile, validate=False)
 
         image['superpixelsId'] = superpixelsFile['_id']
         self.save(image)

--- a/server/models/segmentation.py
+++ b/server/models/segmentation.py
@@ -115,12 +115,14 @@ class Segmentation(Model):
                 obj=maskOutputStream,
                 size=len(maskOutputStream.getvalue()),
                 name='%s_segmentation.png' % (image['name']),
-                parentType=None,
-                parent=None,
+                # TODO: change this once a bug in upstream Girder is fixed
+                parentType='segmentation',
+                parent=segmentation,
+                attachParent=True,
                 user=creator,
-                mimeType='image/png',
+                mimeType='image/png'
             )
-            maskFile['attachedToId'] = segmentation['_id']
+            # TODO: remove this once a bug in upstream Girder is fixed
             maskFile['attachedToType'] = ['segmentation', 'isic_archive']
             maskFile = File.save(maskFile)
 

--- a/server/provision_utility.py
+++ b/server/provision_utility.py
@@ -35,6 +35,9 @@ def getAdminUser():
             admin=True,
             public=False
         )
+        adminUser['status'] = 'disabled'
+        # TODO: subsequent re-saves of this user will re-enable it, until another user is created
+        adminUser = User.save(adminUser, validate=False)
     return adminUser
 
 

--- a/server/provision_utility.py
+++ b/server/provision_utility.py
@@ -20,8 +20,6 @@
 from girder.constants import AccessType, SettingKey
 from girder.utility.model_importer import ModelImporter
 
-from . import constants
-
 
 def getAdminUser():
     User = ModelImporter.model('user', 'isic_archive')
@@ -159,9 +157,6 @@ def provisionDatabase():
     Setting = ModelImporter.model('setting')
 
     Setting.set(SettingKey.USER_DEFAULT_FOLDERS, 'none')
-
-    if Setting.get(constants.PluginSettings.DEMO_MODE, None) is None:
-        Setting.set(constants.PluginSettings.DEMO_MODE, False)
 
     _provisionImages()
     _provisionSegmentationGroups()

--- a/server/settings.py
+++ b/server/settings.py
@@ -17,8 +17,29 @@
 #  limitations under the License.
 ###############################################################################
 
+from girder.constants import SettingDefault
+from girder.models.model_base import ValidationException
+from girder.utility import setting_utilities
+
 
 class PluginSettings(object):
     DEMO_MODE = 'isic.demo_mode'
-
     MAX_ISIC_ID = 'isic.max_isic_id'
+
+
+@setting_utilities.validator(PluginSettings.DEMO_MODE)
+def validateDemoModeSetting(doc):
+    if not isinstance(doc['value'], bool):
+        raise ValidationException('Demo mode must be provided as a boolean.', 'value')
+
+
+@setting_utilities.validator(PluginSettings.MAX_ISIC_ID)
+def validateMaxIsicIdSetting(doc):
+    # TODO: can we disable this from being set via the HTTP API?
+    if not isinstance(doc['value'], int):
+        raise ValidationException('Maximum ISIC ID must be provided as an integer.', 'value')
+
+
+def registerDefaults():
+    SettingDefault.defaults[PluginSettings.DEMO_MODE] = False
+    SettingDefault.defaults[PluginSettings.MAX_ISIC_ID] = -1

--- a/web_external/Datasets/uploadDataset.jade
+++ b/web_external/Datasets/uploadDataset.jade
@@ -8,15 +8,15 @@
         Enter the dataset's name, the dataset's owner, and a detailed
         description. The owner may be an individual or an institution.
       .form-group
-        label(for="isic-dataset-name") Name
+        label(for='isic-dataset-name') Name
         input#isic-dataset-name.form-control.input-sm(
-          type="text")
+          type='text')
       .form-group
-        label(for="isic-dataset-owner") Owner
+        label(for='isic-dataset-owner') Owner
         input#isic-dataset-owner.form-control.input-sm(
-          type="text")
+          type='text')
       .form-group
-        label.control-label(for="isic-dataset-description") Description
+        label.control-label(for='isic-dataset-description') Description
         textarea.input-sm#isic-dataset-description.form-control
     .isic-form-group
       h3 Upload images
@@ -33,13 +33,13 @@
         Select the license for the dataset and enter your name to
         electronically sign the contributor license agreement.
       .form-group
-        label.control-label(for="isic-dataset-license") License
+        label.control-label(for='isic-dataset-license') License
         select#isic-dataset-license.form-control.input-sm
-          option(value="CC-0")
+          option(value='CC-0')
             | CC-0 (No restrictions)
-          option(value="CC-BY")
+          option(value='CC-BY')
             | CC-BY (Attribution)
-          option(value="CC-BY-NC")
+          option(value='CC-BY-NC')
             | CC-BY-NC (Attribution-NonCommercial)
         .isic-dataset-agreement-link-container
           a#isic-upload-show-license-info-link.isic-dataset-agreement-link
@@ -49,10 +49,10 @@
           | Contributor license agreement
         #isic-terms-of-use-container
       .form-group
-        label(for="isic-dataset-agreement-signature") Electronic signature
+        label(for='isic-dataset-agreement-signature') Electronic signature
         input#isic-dataset-agreement-signature.form-control.input-sm(
-          type="text"
-          placeholder="Enter your name")
+          type='text'
+          placeholder='Enter your name')
     .isic-form-group
       h3 Attribution
       p.
@@ -62,16 +62,16 @@
         .radio
           label
             input#isic-dataset-attribution-anonymous(
-              type="radio" name="attribution" value="anonymous")
+              type='radio' name='attribution' value='anonymous')
             | Anonymous
         .radio
           label
             input#isic-dataset-attribution-attributed-to(
-              type="radio" name="attribution" value="attributed-to" checked="on")
+              type='radio' name='attribution' value='attributed-to' checked='on')
             | Attributed to:
           input#isic-dataset-attribution-name.form-control.input-sm(
-            type="text")
+            type='text')
 
   p
-    form#isic-dataset-form(role="form")
-      button#isic-dataset-submit.btn.btn-primary.btn-md(type="submit") Submit
+    form#isic-dataset-form(role='form')
+      button#isic-dataset-submit.btn.btn-primary.btn-md(type='submit') Submit

--- a/web_external/Datasets/uploadDatasetLicenseInfoPage.jade
+++ b/web_external/Datasets/uploadDatasetLicenseInfoPage.jade
@@ -1,18 +1,18 @@
 .modal-dialog.isic-upload-dataset-license-info-container
   .modal-content
     .modal-header
-      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      button.close(data-dismiss='modal' aria-hidden='true' type='button') &times;
       h4.modal-title
         | Licenses
     .modal-body
-      .alert.alert-info(role="alert")
+      .alert.alert-info(role='alert')
         i.icon-attention-circled
         .isic-upload-dataset-license-info-alert-content
           | The ISIC recommends that dataset contributors choose the <b>CC-0</b> or <b>CC-BY</b> licenses whenever possible.
 
       h4.isic-upload-dataset-license-info-title
         p
-          img(src="https://licensebuttons.net/l/zero/1.0/88x31.png")
+          img(src='https://licensebuttons.net/l/zero/1.0/88x31.png')
         | CC-0 (No restrictions)
       p.
         CC-0 enables scientists, educators, artists and other creators and
@@ -21,34 +21,34 @@
         possible in the public domain, so that others may freely build upon,
         enhance and reuse the works for any purposes without restriction under
         copyright or database law.
-      a(href="https://creativecommons.org/publicdomain/zero/1.0/", target="_blank")
+      a(href='https://creativecommons.org/publicdomain/zero/1.0/' target='_blank')
         | View License Deed&nbsp;
         i.icon-link-ext
 
       h4.isic-upload-dataset-license-info-title
         p
-          img(src="https://licensebuttons.net/l/by/4.0/88x31.png")
+          img(src='https://licensebuttons.net/l/by/4.0/88x31.png')
         | CC-BY (Attribution)
       p.
         This license lets others distribute, remix, tweak, and build upon your
         work, even commercially, as long as they credit you for the original
         creation.
-      a(href="https://creativecommons.org/licenses/by/4.0", target="_blank")
+      a(href='https://creativecommons.org/licenses/by/4.0' target='_blank')
         | View License Deed&nbsp;
         i.icon-link-ext
 
       h4.isic-upload-dataset-license-info-title
         p
-          img(src="https://licensebuttons.net/l/by-nc/4.0/88x31.png")
+          img(src='https://licensebuttons.net/l/by-nc/4.0/88x31.png')
         | CC-BY-NC (Attribution-NonCommercial)
       p.
         This license lets others remix, tweak, and build upon your work
         non-commercially, and although their new works must also acknowledge
         you and be non-commercial, they don’t have to license their derivative
         works on the same terms.
-      a(href="https://creativecommons.org/licenses/by-nc/4.0", target="_blank")
+      a(href='https://creativecommons.org/licenses/by-nc/4.0' target='_blank')
         | View License Deed&nbsp;
         i.icon-link-ext
 
     .modal-footer
-      a.btn.btn-small.btn-primary(data-dismiss="modal") Close
+      a.btn.btn-small.btn-primary(data-dismiss='modal') Close

--- a/web_external/Datasets/uploadDatasetLicenseInfoPage.jade
+++ b/web_external/Datasets/uploadDatasetLicenseInfoPage.jade
@@ -21,7 +21,7 @@
         possible in the public domain, so that others may freely build upon,
         enhance and reuse the works for any purposes without restriction under
         copyright or database law.
-      a(href='https://creativecommons.org/publicdomain/zero/1.0/' target='_blank')
+      a(href='https://creativecommons.org/publicdomain/zero/1.0/' target='_blank' rel='noopener')
         | View License Deed&nbsp;
         i.icon-link-ext
 
@@ -33,7 +33,7 @@
         This license lets others distribute, remix, tweak, and build upon your
         work, even commercially, as long as they credit you for the original
         creation.
-      a(href='https://creativecommons.org/licenses/by/4.0' target='_blank')
+      a(href='https://creativecommons.org/licenses/by/4.0' target='_blank' rel='noopener')
         | View License Deed&nbsp;
         i.icon-link-ext
 
@@ -46,7 +46,7 @@
         non-commercially, and although their new works must also acknowledge
         you and be non-commercial, they don’t have to license their derivative
         works on the same terms.
-      a(href='https://creativecommons.org/licenses/by-nc/4.0' target='_blank')
+      a(href='https://creativecommons.org/licenses/by-nc/4.0' target='_blank' rel='noopener')
         | View License Deed&nbsp;
         i.icon-link-ext
 

--- a/web_external/Datasets/uploadDatasetRequest.jade
+++ b/web_external/Datasets/uploadDatasetRequest.jade
@@ -7,9 +7,9 @@
       p.
         Thank you for your interest in contributing to the ISIC Archive.
         We accept dermoscopic images with metadata, under
-        #[a(href="https://creativecommons.org/publicdomain/zero/1.0/", target="_blank") CC-0],
-        #[a(href="https://creativecommons.org/licenses/by/4.0/", target="_blank") CC-BY] and
-        #[a(href="https://creativecommons.org/licenses/by-nc/4.0/", target="_blank") CC-BY-NC] licenses.
+        #[a(href='https://creativecommons.org/publicdomain/zero/1.0/' target='_blank') CC-0],
+        #[a(href='https://creativecommons.org/licenses/by/4.0/' target='_blank') CC-BY] and
+        #[a(href='https://creativecommons.org/licenses/by-nc/4.0/' target='_blank') CC-BY-NC] licenses.
         Please click below to request access to contribute images:
-      form#isic-dataset-form.text-center(role="form")
-        button#isic-dataset-submit.btn.btn-primary.btn-md.text-center(type="submit") Request access
+      form#isic-dataset-form.text-center(role='form')
+        button#isic-dataset-submit.btn.btn-primary.btn-md.text-center(type='submit') Request access

--- a/web_external/Datasets/uploadDatasetRequest.jade
+++ b/web_external/Datasets/uploadDatasetRequest.jade
@@ -7,9 +7,9 @@
       p.
         Thank you for your interest in contributing to the ISIC Archive.
         We accept dermoscopic images with metadata, under
-        #[a(href='https://creativecommons.org/publicdomain/zero/1.0/' target='_blank') CC-0],
-        #[a(href='https://creativecommons.org/licenses/by/4.0/' target='_blank') CC-BY] and
-        #[a(href='https://creativecommons.org/licenses/by-nc/4.0/' target='_blank') CC-BY-NC] licenses.
+        #[a(href='https://creativecommons.org/publicdomain/zero/1.0/' target='_blank' rel='noopener') CC-0],
+        #[a(href='https://creativecommons.org/licenses/by/4.0/' target='_blank' rel='noopener') CC-BY] and
+        #[a(href='https://creativecommons.org/licenses/by-nc/4.0/' target='_blank' rel='noopener') CC-BY-NC] licenses.
         Please click below to request access to contribute images:
       form#isic-dataset-form.text-center(role='form')
         button#isic-dataset-submit.btn.btn-primary.btn-md.text-center(type='submit') Request access

--- a/web_external/Featuresets/featuresetListEntry.jade
+++ b/web_external/Featuresets/featuresetListEntry.jade
@@ -2,5 +2,5 @@
   .isic-list-entry-col-left.isic-featureset-list-entry-col-left
     .isic-featureset-list-entry-title #{featureset.text}
   .isic-list-entry-col-right.isic-featureset-list-entry-col-right
-    a.isic-list-entry-action-remove.isic-featureset-list-entry-action-remove(title="Remove")
+    a.isic-list-entry-action-remove.isic-featureset-list-entry-action-remove(title='Remove')
       i.icon-cancel

--- a/web_external/Front/frontPage.jade
+++ b/web_external/Front/frontPage.jade
@@ -10,11 +10,11 @@
         span.
           The ISIC is now sponsoring a Grand Challenge for the 2017 International
           Symposium on Biomedical Imaging
-          (ISBI): #[a(href='http://biomedicalimaging.org/2017/challenges/') "ISIC 2017: Skin Lesion Analysis towards Melanoma Detection"].
+          (ISBI): #[a(href='http://biomedicalimaging.org/2017/challenges/' target='_blank' rel='noopener') "ISIC 2017: Skin Lesion Analysis towards Melanoma Detection"].
         br
         span(style='margin-left: 19.6px;').
           For more details, or to register and download the
-          datasets, #[a(href='http://challenge.isic-archive.com') click here].
+          datasets, #[a(href='http://challenge.isic-archive.com' target='_blank' rel='noopener') click here].
     .row
       .col-lg-6
         h3 Introduction

--- a/web_external/Front/frontPage.jade
+++ b/web_external/Front/frontPage.jade
@@ -4,17 +4,17 @@
       h1 ISIC Archive
       h2 International Skin Imaging Collaboration: Melanoma Project
   .isic-frontpage-body.container
-    .row.alert.alert-warning(style="margin-top: 20px; margin-bottom: 0;")
+    .row.alert.alert-warning(style='margin-top: 20px; margin-bottom: 0;')
       p
         i.icon-info
         span.
           The ISIC is now sponsoring a Grand Challenge for the 2017 International
           Symposium on Biomedical Imaging
-          (ISBI): #[a(href="http://biomedicalimaging.org/2017/challenges/") "ISIC 2017: Skin Lesion Analysis towards Melanoma Detection"].
+          (ISBI): #[a(href='http://biomedicalimaging.org/2017/challenges/') "ISIC 2017: Skin Lesion Analysis towards Melanoma Detection"].
         br
-        span(style="margin-left: 19.6px;").
+        span(style='margin-left: 19.6px;').
           For more details, or to register and download the
-          datasets, #[a(href="http://challenge.isic-archive.com") click here].
+          datasets, #[a(href='http://challenge.isic-archive.com') click here].
     .row
       .col-lg-6
         h3 Introduction
@@ -66,21 +66,21 @@
           |  dermoscopic images, as these are most diagnostic for melanoma.
           |  An example of lesion segmentation is shown here:
         img(
-          src='#{staticRoot}/built/plugins/isic_archive/extra/img/segmentation.png',
-          alt='ISIC Archive segmentation interface',
+          src='#{staticRoot}/built/plugins/isic_archive/extra/img/segmentation.png'
+          alt='ISIC Archive segmentation interface'
           width='555')
         p
           | An example of lesion annotation is shown below:
         img(
-          src='#{staticRoot}/built/plugins/isic_archive/extra/img/annotation.png',
-          alt='ISIC Archive annotation interface',
+          src='#{staticRoot}/built/plugins/isic_archive/extra/img/annotation.png'
+          alt='ISIC Archive annotation interface'
           width='555')
       .col-lg-6
         h3 Gallery of Current Images
         a(href='#images')
           img(
-            src='#{staticRoot}/built/plugins/isic_archive/extra/img/lesiondatasets.png',
-            alt='ISIC Archive lesion dataset thumbnails',
+            src='#{staticRoot}/built/plugins/isic_archive/extra/img/lesiondatasets.png'
+            alt='ISIC Archive lesion dataset thumbnails'
             width='555'
             title='Image Gallery')
         h3 Current Datasets

--- a/web_external/ImagesGallery/Detail/imageDetailsPage.jade
+++ b/web_external/ImagesGallery/Detail/imageDetailsPage.jade
@@ -47,7 +47,7 @@
           td License
           td
             if license.url
-              a(target='_blank', href=license.url)= license.name
+              a(href=license.url target='_blank')= license.name
             else
               = license.name
 

--- a/web_external/ImagesGallery/Detail/imageDetailsPage.jade
+++ b/web_external/ImagesGallery/Detail/imageDetailsPage.jade
@@ -15,6 +15,7 @@
         title='Open this image in a new window'
         href=apiRoot + '/image/' + image.id + '/download?contentDisposition=inline'
         target='_blank'
+        rel='noopener'
       )
         i.icon-link-ext
       a#isic-image-details-download.isic-image-details-button.btn.btn-xs.btn-default(
@@ -47,7 +48,7 @@
           td License
           td
             if license.url
-              a(href=license.url target='_blank')= license.name
+              a(href=license.url target='_blank' rel='noopener')= license.name
             else
               = license.name
 

--- a/web_external/ImagesGallery/Filter/imagesFacetHistogram.jade
+++ b/web_external/ImagesGallery/Filter/imagesFacetHistogram.jade
@@ -5,20 +5,20 @@ block content
     g.yAxis
     g.yAxisKnob
       rect(
-        transform="rotate(45)",
-        width="0.5em",
-        height="0.5em",
-        x="-0.25em",
-        y="-0.25em")
+        transform='rotate(45)'
+        width='0.5em'
+        height='0.5em'
+        x='-0.25em'
+        y='-0.25em')
     g.selectAllBins
       image.selectAll.button(
-        width="1em",
-        height="1em",
-        x="-0.5em",
-        y="-0em",
-        xlink:href="#{staticRoot}/built/plugins/isic_archive/extra/img/check.svg")
+        width='1em'
+        height='1em'
+        x='-0.5em'
+        y='-0em'
+        xlink:href='#{staticRoot}/built/plugins/isic_archive/extra/img/check.svg')
       text(
-        transform="rotate(90)",
-        x="1.5em",
-        y="0.5em") Select All
+        transform='rotate(90)'
+        x='1.5em'
+        y='0.5em') Select All
     g.bins

--- a/web_external/Studies/createStudyPage.jade
+++ b/web_external/Studies/createStudyPage.jade
@@ -7,9 +7,9 @@
       p.
         Enter a name for the new annotation study.
       .form-group
-        label(for="isic-study-name") Name
+        label(for='isic-study-name') Name
         input#isic-study-name.form-control.input-sm(
-          type="text")
+          type='text')
 
     .isic-form-group
       h3 Users
@@ -30,5 +30,5 @@
       .isic-study-search-field-container.isic-study-featureset-search-field-container
 
   p
-    form#isic-study-form(role="form")
-      button#isic-study-submit.btn.btn-primary.btn-md(type="submit") Submit
+    form#isic-study-form(role='form')
+      button#isic-study-submit.btn.btn-primary.btn-md(type='submit') Submit

--- a/web_external/Studies/studiesPage.jade
+++ b/web_external/Studies/studiesPage.jade
@@ -4,7 +4,7 @@ block title
   if studyAdmin
     = title
     a.isic-study-add-button.btn.btn-default.btn-sm.isic-tooltip(
-      title="Create new study")
+      title='Create new study')
       i.icon-plus
   else
     = title

--- a/web_external/Studies/studyAddUserWidget.jade
+++ b/web_external/Studies/studyAddUserWidget.jade
@@ -1,7 +1,7 @@
 .modal-dialog
   .modal-content
     .modal-header
-      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      button.close(data-dismiss='modal' aria-hidden='true' type='button') &times;
       h4.modal-title
         | Add user
       i.icon-eye
@@ -13,7 +13,7 @@
       .isic-user-container
         | (none)
     .modal-footer
-      a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
+      a.btn.btn-small.btn-default(data-dismiss='modal') Cancel
       button.isic-add-user-ok-button.btn.btn-small.btn-primary
         i.icon-edit
         | OK

--- a/web_external/Studies/studyPage.jade
+++ b/web_external/Studies/studyPage.jade
@@ -5,7 +5,7 @@
   h4 Users
     if studyAdmin
       a.isic-study-add-user-button.btn.btn-default.btn-sm.isic-tooltip(
-        title="Add user")
+        title='Add user')
         i.icon-plus
   .isic-listing-content.isic-study-users-content
     if study.get('users').length

--- a/web_external/Studies/userListEntry.jade
+++ b/web_external/Studies/userListEntry.jade
@@ -2,5 +2,5 @@
   .isic-list-entry-col-left.isic-user-list-entry-col-left
     .isic-user-list-entry-title #{user.text}
   .isic-list-entry-col-right.isic-user-list-entry-col-right
-    a.isic-list-entry-action-remove.isic-user-list-entry-action-remove(title="Remove")
+    a.isic-list-entry-action-remove.isic-user-list-entry-action-remove(title='Remove')
       i.icon-cancel

--- a/web_external/StudyResults/studyResultsGlobalFeaturesTable.jade
+++ b/web_external/StudyResults/studyResultsGlobalFeaturesTable.jade
@@ -6,7 +6,7 @@ table.table.table-condensed.isic-study-results-global-features-table
   tbody
     each feature in features
       tr
-        td.isic-study-results-annotation-feature-id(title="#{feature.name()}", class={disabled: !feature.has('resultName')})
+        td.isic-study-results-annotation-feature-id(title='#{feature.name()}' class={disabled: !feature.has('resultName')})
           code= feature.id
-        td.isic-study-results-annotation-feature-value(title="#{feature.get('resultId')}")
+        td.isic-study-results-annotation-feature-value(title='#{feature.get("resultId")}')
           = feature.get('resultName')

--- a/web_external/StudyResults/studyResultsPage.jade
+++ b/web_external/StudyResults/studyResultsPage.jade
@@ -25,11 +25,11 @@
       // Tabs
       ul.nav.nav-tabs
         li.active
-          a(data-toggle="tab" href='#isic-study-results-image-preview-tab-content')#isic-study-results-image-preview-tab Image Preview
+          a(data-toggle='tab' href='#isic-study-results-image-preview-tab-content')#isic-study-results-image-preview-tab Image Preview
         li
-          a(data-toggle="tab" href='#isic-study-results-global-features-tab-content')#isic-study-results-global-features-tab Global Features
+          a(data-toggle='tab' href='#isic-study-results-global-features-tab-content')#isic-study-results-global-features-tab Global Features
         li
-          a(data-toggle="tab" href='#isic-study-results-local-features-tab-content')#isic-study-results-local-features-tab Local Features
+          a(data-toggle='tab' href='#isic-study-results-local-features-tab-content')#isic-study-results-local-features-tab Local Features
 
       // Tab content
       .tab-content

--- a/web_external/StudyResults/studyResultsSelectImagePage.jade
+++ b/web_external/StudyResults/studyResultsSelectImagePage.jade
@@ -4,7 +4,7 @@
     .isic-study-results-select-image-image-container(data-image-id=model.id)
       span= model.name()
       img(
-        src=apiRoot + '/image/' + model.id + '/thumbnail?width=' + thumbnailSize,
-        width=thumbnailSize,
+        src=apiRoot + '/image/' + model.id + '/thumbnail?width=' + thumbnailSize
+        width=thumbnailSize
         height=thumbnailSize
       )

--- a/web_external/StudyResults/studyResultsSelectStudyPage.jade
+++ b/web_external/StudyResults/studyResultsSelectStudyPage.jade
@@ -5,5 +5,5 @@
     each model in models
       option(value=model.id)= model.name()
   a.isic-study-results-select-study-details-button.btn.btn-default.isic-tooltip(
-    title="View study details" disabled)
+    title='View study details' disabled)
     i.icon-list

--- a/web_external/StudyResults/studyResultsStudyDetailPage.jade
+++ b/web_external/StudyResults/studyResultsStudyDetailPage.jade
@@ -1,7 +1,7 @@
 .modal-dialog
   .modal-content
     .modal-header
-      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      button.close(data-dismiss='modal' aria-hidden='true' type='button') &times;
       h4.modal-title
         | Study details
       i.icon-eye
@@ -21,4 +21,4 @@
               td.isic-study-results-study-details-table-label Creator
               td= model.creator().name()
     .modal-footer
-      a.btn.btn-small.btn-primary(data-dismiss="modal") Close
+      a.btn.btn-small.btn-primary(data-dismiss='modal') Close

--- a/web_external/Tasks/tasksPage.jade
+++ b/web_external/Tasks/tasksPage.jade
@@ -1,7 +1,7 @@
 .container.isic-tasks-container
   h2.isic-page-title= title
     a.isic-tasks-refresh-button.btn.btn-default.btn-sm.isic-tooltip(
-      title="Refresh")
+      title='Refresh')
       i.icon-cw
   .row
     .col-lg-6
@@ -9,7 +9,7 @@
       #isic-tasks-segmentation-container
       #isic-tasks-annotation-container
     .col-lg-2
-      iframe.isic-tasks-video(width="420" height="315" src="https://www.youtube.com/embed/fxPZR3mayCM", frameborder="0", allowfullscreen)
-      iframe.isic-tasks-video(width="420" height="315" src="https://www.youtube.com/embed/NRFNyHraGvM", frameborder="0", allowfullscreen)
-      iframe.isic-tasks-video(width="420" height="315" src="https://www.youtube.com/embed/lis4xgoFUeo", frameborder="0", allowfullscreen)
-      iframe.isic-tasks-video(width="420" height="315" src="https://www.youtube.com/embed/2vMgFFE41o0", frameborder="0", allowfullscreen)
+      iframe.isic-tasks-video(width='420' height='315' src='https://www.youtube.com/embed/fxPZR3mayCM' frameborder='0' allowfullscreen)
+      iframe.isic-tasks-video(width='420' height='315' src='https://www.youtube.com/embed/NRFNyHraGvM' frameborder='0' allowfullscreen)
+      iframe.isic-tasks-video(width='420' height='315' src='https://www.youtube.com/embed/lis4xgoFUeo' frameborder='0' allowfullscreen)
+      iframe.isic-tasks-video(width='420' height='315' src='https://www.youtube.com/embed/2vMgFFE41o0' frameborder='0' allowfullscreen)

--- a/web_external/common/Listing/listingPage.jade
+++ b/web_external/common/Listing/listingPage.jade
@@ -17,12 +17,12 @@
 .isic-listing-paginate-container
 .isic-listing-container
   each model, index in models
-    .isic-listing-panel-group.panel-group(id="#{'panel-group-' + model.cid}")
+    .isic-listing-panel-group.panel-group(id='#{"panel-group-" + model.cid}')
       .isic-listing-panel.panel.panel-default
         .isic-listing-panel-heading.panel-heading(
-          data-toggle="collapse",
-          data-parent="#{'#panel-group-' + model.cid}",
-          data-target="#{'#panel-' + model.cid}"
+          data-toggle='collapse'
+          data-parent='#{"#panel-group-" + model.cid}'
+          data-target='#{"#panel-" + model.cid}'
           )
           a.collapsed
             block heading
@@ -30,8 +30,8 @@
             span.isic-listing-panel-heading-indicator.pull-right
               i.icon-right-open
         .isic-listing-panel-collapse.panel-collapse.collapse(
-          id="#{'panel-' + model.cid}"
-          data-model-index="#{index}"
+          id='#{"panel-" + model.cid}'
+          data-model-index='#{index}'
           )
           .isic-listing-panel-body.panel-body
 

--- a/web_external/common/TermsOfUse/termsOfUseWidget.jade
+++ b/web_external/common/TermsOfUse/termsOfUseWidget.jade
@@ -4,9 +4,9 @@
       include ../../Legal/legal/terms_of_use.html
 
   .isic-terms-of-use-link-container
-    a.isic-terms-of-use-link(href="#{documentsRoot}/Terms of Use.txt" download="Terms of Use.txt")
+    a.isic-terms-of-use-link(href='#{documentsRoot}/Terms of Use.txt' download='Terms of Use.txt')
       i.icon-doc-text
       | Download as text
-    a.isic-terms-of-use-link(href="#{documentsRoot}/Terms of Use.pdf" download="Terms of Use.pdf")
+    a.isic-terms-of-use-link(href='#{documentsRoot}/Terms of Use.pdf' download='Terms of Use.pdf')
       i.icon-file-pdf
       | Download as PDF

--- a/web_external/common/Viewer/imageFullscreenWidget.jade
+++ b/web_external/common/Viewer/imageFullscreenWidget.jade
@@ -1,9 +1,9 @@
 .modal-dialog.isic-image-fullscreen-dialog
   .modal-content
     .modal-header
-      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      button.close(data-dismiss='modal' aria-hidden='true' type='button') &times;
       h4.modal-title= model.name()
     .modal-body
       .isic-image-fullscreen-container
     .modal-footer
-      a.btn.btn-small.btn-primary(data-dismiss="modal") Close
+      a.btn.btn-small.btn-primary(data-dismiss='modal') Close

--- a/web_external/common/alertDialog.jade
+++ b/web_external/common/alertDialog.jade
@@ -4,5 +4,5 @@
       p
     .modal-footer
       a#isic-alert-dialog-button.btn.btn-small.btn-default(
-        class="#{params.buttonClass}",
-        data-dismiss="modal")= params.buttonText
+        class='#{params.buttonClass}'
+        data-dismiss='modal')= params.buttonText

--- a/web_external/layout/layout.jade
+++ b/web_external/layout/layout.jade
@@ -7,5 +7,5 @@
 //- Set tabindex on modal element to allow closing modal by pressing Escape. See:
 //- - http://getbootstrap.com/javascript/#modals-examples
 //- - http://stackoverflow.com/questions/12630156/
-#g-dialog-container.modal.fade(tabindex="-1")
+#g-dialog-container.modal.fade(tabindex='-1')
 #g-alerts-container

--- a/web_external/layout/layoutFooter.jade
+++ b/web_external/layout/layoutFooter.jade
@@ -6,22 +6,22 @@
           | &copy; Kitware, Inc.
         li
           | Powered by
-          a#g-about-link(href="http://girder.readthedocs.org/en/latest/user-guide.html")  Girder
+          a#g-about-link(href='http://girder.readthedocs.org/en/latest/user-guide.html')  Girder
 
     .isic-footer-legal.col-md-4
       ul
         li
-          a(href="#termsOfUse") Terms of Use
+          a(href='#termsOfUse') Terms of Use
         li
-          a(href="#privacyPolicy") Privacy Policy
-        li.isic-footer-disclaimer(data-content="All information on this website is for education and information purposes only. For specific medical advice, diagnoses, and treatment, seek expert, specific medical care. Click the link below to see our Medical Disclaimer in its entirety.")
-          a(href="#medicalDisclaimer") Medical Disclaimer
+          a(href='#privacyPolicy') Privacy Policy
+        li.isic-footer-disclaimer(data-content='All information on this website is for education and information purposes only. For specific medical advice, diagnoses, and treatment, seek expert, specific medical care. Click the link below to see our Medical Disclaimer in its entirety.')
+          a(href='#medicalDisclaimer') Medical Disclaimer
 
     .isic-footer-links.col-md-4
       ul
         li
-          a#g-contact-link(href="mailto:admin@isic-archive.com") Contact
+          a#g-contact-link(href='mailto:admin@isic-archive.com') Contact
         li
-          a(href="#{apiRoot}") Web API
+          a(href='#{apiRoot}') Web API
         li
-          a#g-bug-link(href="https://github.com/ImageMarkup/isic-archive/issues/new") Report a bug
+          a#g-bug-link(href='https://github.com/ImageMarkup/isic-archive/issues/new') Report a bug

--- a/web_external/layout/layoutFooter.jade
+++ b/web_external/layout/layoutFooter.jade
@@ -6,7 +6,7 @@
           | &copy; Kitware, Inc.
         li
           | Powered by
-          a#g-about-link(href='http://girder.readthedocs.org/en/latest/user-guide.html')  Girder
+          a#g-about-link(href='http://girder.readthedocs.org/en/latest/user-guide.html' target='_blank' rel='noopener')  Girder
 
     .isic-footer-legal.col-md-4
       ul
@@ -24,4 +24,4 @@
         li
           a(href='#{apiRoot}') Web API
         li
-          a#g-bug-link(href='https://github.com/ImageMarkup/isic-archive/issues/new') Report a bug
+          a#g-bug-link(href='https://github.com/ImageMarkup/isic-archive/issues/new' target='_blank' rel='noopener') Report a bug

--- a/web_external/layout/layoutHeader.jade
+++ b/web_external/layout/layoutHeader.jade
@@ -2,112 +2,112 @@ nav.navbar.navbar-default.navbar-fixed-top.isic-header-wrapper
   .container-fluid
 
     .navbar-header
-      button.navbar-toggle.collapsed(type="button", data-toggle="collapse", data-target="#isic-navbar-collapse", aria-expanded=false)
+      button.navbar-toggle.collapsed(type='button' data-toggle='collapse' data-target='#isic-navbar-collapse' aria-expanded=false)
         span.sr-only Toggle navigation
         i.icon-bar
         i.icon-bar
         i.icon-bar
-      a.navbar-brand.isic-header-title(href="#") ISIC Archive
+      a.navbar-brand.isic-header-title(href='#') ISIC Archive
 
     #isic-navbar-collapse.collapse.navbar-collapse
       ul.nav.navbar-nav
 
         li.dropdown
-          a.dropdown-toggle.isic-header-item(href="#", role="button", aria-haspopup="true" aria-expanded="false")
+          a.dropdown-toggle.isic-header-item(href='#' role='button' aria-haspopup='true' aria-expanded='false')
             | About&nbsp;
             span.caret
           ul.dropdown-menu
-            li(role="presentation")
-              a(title="Home", href="#")
+            li(role='presentation')
+              a(title='Home' href='#')
                 i.icon-home
                 | Home
-            li(role="presentation")
-              a(title="ISIC Project", href="http://isdis.net/isic-project/", target="_blank")
+            li(role='presentation')
+              a(title='ISIC Project' href='http://isdis.net/isic-project/' target='_blank')
                 i.icon-help
                 | ISIC Project
                 i.icon-link-ext
-            li(role="presentation")
-              a(title="Working Group Members", href="http://isdis.net/isic-project/working-group-members/", target="_blank")
+            li(role='presentation')
+              a(title='Working Group Members' href='http://isdis.net/isic-project/working-group-members/' target='_blank')
                 i.icon-users
                 | Working Group Members
                 i.icon-link-ext
-            li.divider(role="separator")
+            li.divider(role='separator')
             li.dropdown-header
               | Policies
-            li(role="presentation")
-              a(title="Terms of Use", href="#termsOfUse")
+            li(role='presentation')
+              a(title='Terms of Use' href='#termsOfUse')
                 i.icon-doc-text
                 | Terms of Use
-            li(role="presentation")
-              a(title="Privacy Policy", href="#privacyPolicy")
+            li(role='presentation')
+              a(title='Privacy Policy' href='#privacyPolicy')
                 i.icon-doc-text
                 | Privacy Policy
-            li(role="presentation")
-              a(title="Medical Disclaimer", href="#medicalDisclaimer")
+            li(role='presentation')
+              a(title='Medical Disclaimer' href='#medicalDisclaimer')
                 i.icon-doc-text
                 | Medical Disclaimer
 
         li.dropdown
-          a.dropdown-toggle.isic-header-item(href="#", role="button", aria-haspopup="true" aria-expanded="false")
+          a.dropdown-toggle.isic-header-item(href='#' role='button' aria-haspopup='true' aria-expanded='false')
             | Community&nbsp;
             span.caret
           ul.dropdown-menu
-            li(role="presentation")
-              a(title="Forum", href="#forum")
+            li(role='presentation')
+              a(title='Forum' href='#forum')
                 i.icon-chat
                 | Forum
                 i.icon-link-ext
-            li(role="presentation")
-              a(title="2016 ISBI Grand Challenge", href="http://challenge2016.isic-archive.com", target="_blank")
+            li(role='presentation')
+              a(title='2016 ISBI Grand Challenge' href='http://challenge2016.isic-archive.com' target='_blank')
                 i.icon-award
                 | 2016 ISBI Grand Challenge
                 i.icon-link-ext
-            li(role="presentation")
-              a(title="2017 ISBI Grand Challenge", href="http://challenge2017.isic-archive.com", target="_blank")
+            li(role='presentation')
+              a(title='2017 ISBI Grand Challenge' href='http://challenge2017.isic-archive.com' target='_blank')
                 i.icon-award
                 | 2017 ISBI Grand Challenge
                 i.icon-link-ext
 
         li.dropdown
-          a.dropdown-toggle.isic-header-item(href="#images", role="button", aria-haspopup="true" aria-expanded="false")
+          a.dropdown-toggle.isic-header-item(href='#images' role='button' aria-haspopup='true' aria-expanded='false')
             | Lesion Images&nbsp;
             span.caret
           ul.dropdown-menu
-            li(role="presentation")
-              a(title="Datasets", href="#dataset")
+            li(role='presentation')
+              a(title='Datasets' href='#dataset')
                 i.icon-list
                 | Datasets
             if currentUser
-              li(role="presentation")
-                a(title="Upload Dataset", href="#dataset/upload")
+              li(role='presentation')
+                a(title='Upload Dataset' href='#dataset/upload')
                   i.icon-upload
                   | Upload Dataset
-            li(role="presentation")
-              a(title="Lesion Images", href="#images")
+            li(role='presentation')
+              a(title='Lesion Images' href='#images')
                 i.icon-picture
                 | Lesion Images
 
         li.dropdown
-          a.dropdown-toggle.isic-header-item(href="#studyResults", role="button", aria-haspopup="true" aria-expanded="false")
+          a.dropdown-toggle.isic-header-item(href='#studyResults' role='button' aria-haspopup='true' aria-expanded='false')
             | Annotation Study Results&nbsp;
             span.caret
           ul.dropdown-menu
-            li(role="presentation")
-              a(title="Featuresets", href="#featuresets")
+            li(role='presentation')
+              a(title='Featuresets' href='#featuresets')
                 i.icon-list
                 | Featuresets
-            li(role="presentation")
-              a(title="Manage Annotation Studies", href="#studies")
+            li(role='presentation')
+              a(title='Manage Annotation Studies' href='#studies')
                 i.icon-pencil
                 | Manage Annotation Studies
-            li(role="presentation")
-              a(title="Annotation Study Results", href="#studyResults")
+            li(role='presentation')
+              a(title='Annotation Study Results' href='#studyResults')
                 i.icon-eye
                 | Annotation Study Results
 
         if currentUser
-          li(role="presentation")
-            a.isic-header-item(title="Your Tasks", href="#tasks")
+          li(role='presentation')
+            a.isic-header-item(title='Your Tasks' href='#tasks')
               i.icon-check
               | Your Tasks
 

--- a/web_external/layout/layoutHeader.jade
+++ b/web_external/layout/layoutHeader.jade
@@ -22,12 +22,12 @@ nav.navbar.navbar-default.navbar-fixed-top.isic-header-wrapper
                 i.icon-home
                 | Home
             li(role='presentation')
-              a(title='ISIC Project' href='http://isdis.net/isic-project/' target='_blank')
+              a(title='ISIC Project' href='http://isdis.net/isic-project/' target='_blank' rel='noopener')
                 i.icon-help
                 | ISIC Project
                 i.icon-link-ext
             li(role='presentation')
-              a(title='Working Group Members' href='http://isdis.net/isic-project/working-group-members/' target='_blank')
+              a(title='Working Group Members' href='http://isdis.net/isic-project/working-group-members/' target='_blank' rel='noopener')
                 i.icon-users
                 | Working Group Members
                 i.icon-link-ext
@@ -58,12 +58,12 @@ nav.navbar.navbar-default.navbar-fixed-top.isic-header-wrapper
                 | Forum
                 i.icon-link-ext
             li(role='presentation')
-              a(title='2016 ISBI Grand Challenge' href='http://challenge2016.isic-archive.com' target='_blank')
+              a(title='2016 ISBI Grand Challenge' href='http://challenge2016.isic-archive.com' target='_blank' rel='noopener')
                 i.icon-award
                 | 2016 ISBI Grand Challenge
                 i.icon-link-ext
             li(role='presentation')
-              a(title='2017 ISBI Grand Challenge' href='http://challenge2017.isic-archive.com' target='_blank')
+              a(title='2017 ISBI Grand Challenge' href='http://challenge2017.isic-archive.com' target='_blank' rel='noopener')
                 i.icon-award
                 | 2017 ISBI Grand Challenge
                 i.icon-link-ext

--- a/web_external/layout/layoutHeaderUser.jade
+++ b/web_external/layout/layoutHeaderUser.jade
@@ -4,16 +4,16 @@
     ul.nav.navbar-nav.navbar-right
       li.navbar-brand.hidden-xs.isic-portrait-wrapper
       li.dropdown
-        a.dropdown-toggle.isic-header-item(href="#", data-toggle="dropdown", role="button", aria-haspopup="true" aria-expanded="false")
+        a.dropdown-toggle.isic-header-item(href='#' data-toggle='dropdown' role='button' aria-haspopup='true' aria-expanded='false')
           | #{user.name()}&nbsp;
           span.caret
         ul.dropdown-menu
-          li(role="presentation")
+          li(role='presentation')
             a.g-my-settings
               i.icon-cog
               | My account
-          li.divider(role="presentation")
-          li(role="presentation")
+          li.divider(role='presentation')
+          li(role='presentation')
             a.g-logout
               i.icon-logout
               | Log out


### PR DESCRIPTION
To migrate the live server:
* Drop the Job collection, as the log is in a new list-based format, and we have no need for the old job entries.
* Set all superpixel files to have `superpixelFile['exts'] = ['png']`
* Update `girder.local.cfg` to use `=` instead of `:` delimiters
* Disable the "isic-admin" user