### PR TITLE
Show dataset description in Bootstrap popover

### DIFF
--- a/web_external/ImagesGallery/Facets/ImagesFacetView.js
+++ b/web_external/ImagesGallery/Facets/ImagesFacetView.js
@@ -460,6 +460,43 @@ isic.views.ImagesFacetCategoricalDatasetView = isic.views.ImagesFacetCategorical
         });
     },
 
+    render: function () {
+        isic.views.ImagesFacetCategoricalView.prototype.render.call(this);
+
+        var self = this;
+
+        this.$('.isic-images-facet-bin').popover({
+            trigger: 'hover',
+            title: function () {
+                // Context is the element that the popover is attached to
+                var datasetId = $(this).data('bin-label');
+                var datasetModel = self.datasetCollection.get(datasetId);
+                return datasetModel.name();
+            },
+            content: function () {
+                // Context is the element that the popover is attached to
+                var datasetId = $(this).data('bin-label');
+                var datasetModel = self.datasetCollection.get(datasetId);
+
+                // Use dataset description if available
+                if (datasetModel.has('description')) {
+                    return datasetModel.get('description');
+                }
+
+                // Fetch dataset details then update content
+                self.listenTo(datasetModel, 'g:fetched', function () {
+                    var description = datasetModel.get('description');
+                    this.$('.popover-content').html(_.escape(description));
+                });
+                datasetModel.fetch();
+                return 'Loading...';
+            },
+            delay: {
+                'show': 100
+            }
+        });
+    },
+
     _getBinTitle: function (completeBin) {
         var datasetModel = this.datasetCollection.get(completeBin.label);
         return datasetModel ? datasetModel.name() : completeBin.label;

--- a/web_external/ImagesGallery/Facets/imagesFacetCategorical.jade
+++ b/web_external/ImagesGallery/Facets/imagesFacetCategorical.jade
@@ -2,14 +2,17 @@ extends imagesFacet
 
 block content
   .isic-images-facet-categorical-content
-    a.isic-images-facet-all-exclude
-      i.icon-minus-squared
-      span.isic-images-facet-bin-name Select none
-    a.isic-images-facet-all-include
-      i.icon-plus-squared
-      span.isic-images-facet-bin-name Select all
+    div
+      a.isic-images-facet-all-exclude
+        i.icon-minus-squared
+        span.isic-images-facet-bin-name Select none
+    div
+      a.isic-images-facet-all-include
+        i.icon-plus-squared
+        span.isic-images-facet-bin-name Select all
     for bin in bins
-      a.isic-images-facet-bin(data-bin-label=bin.label)
-        i.icon-check
-        span.isic-images-facet-bin-name= getBinTitle(bin)
-        span.isic-images-facet-bin-count
+      div
+        a.isic-images-facet-bin(data-bin-label=bin.label data-toggle=popover)
+          i.icon-check
+          span.isic-images-facet-bin-name= getBinTitle(bin)
+          span.isic-images-facet-bin-count

--- a/web_external/ImagesGallery/Facets/imagesFacetsPane.styl
+++ b/web_external/ImagesGallery/Facets/imagesFacetsPane.styl
@@ -98,7 +98,6 @@
       user-select none
 
       a
-        display block
         margin-bottom 2px
         color #333333
 


### PR DESCRIPTION
On the image gallery, show dataset descriptions in a Bootstrap popover
when hovering over the dataset name.

The facet anchor tags are now contained in divs so that the popover
appears to the right of the text instead of to the right of the entire
panel.

Fixes #157.