### PR TITLE
Change the default validity period for invitations to 60 days

### DIFF
--- a/server/api/user.py
+++ b/server/api/user.py
@@ -153,7 +153,7 @@ def acceptTerms(self, params):
     .param('firstName', 'The user\'s first name.')
     .param('lastName', 'The user\'s last name.')
     .param('validityPeriod', 'The number of days that the invite will remain valid.',
-           required=False, dataType='float', default=30.0)
+           required=False, dataType='float', default=60.0)
 )
 @boundHandler(_sharedContext)
 def inviteUser(self, params):
@@ -168,7 +168,7 @@ def inviteUser(self, params):
         except ValueError:
             raise ValidationException('Validity period must be a number.', 'validityPeriod')
     else:
-        validityPeriod = 30.0
+        validityPeriod = 60.0
 
     currentUser = self.getCurrentUser()
     User.requireAdminStudy(currentUser)

--- a/web_external/User/inviteUserPage.pug
+++ b/web_external/User/inviteUserPage.pug
@@ -25,7 +25,7 @@
       .form-group
         label(for='isic-user-invite-period') Time until expiration (optional)
         input#isic-user-invite-period.form-control.input-sm(
-          type='text', placeholder='Enter number of days (default is 30)')
+          type='text', placeholder='Enter number of days (default is 60)')
 
   p
     form#isic-user-invite-form(role='form')


### PR DESCRIPTION
This should give invited new users more time to respond.