### PR TITLE
Ensure thumbnails are rendered correctly in vertically-oriented images

### DIFF
--- a/server/api/image.py
+++ b/server/api/image.py
@@ -237,8 +237,10 @@ class ImageResource(IsicResource):
     @describeRoute(
         Description('Return an image\'s thumbnail.')
         .param('id', 'The ID of the image.', paramType='path')
-        .param('width', 'The desired width for the thumbnail.', paramType='query', required=False,
-               default=256)
+        .param('width', 'The desired maximum width for the thumbnail.', paramType='query',
+               required=False, default=256)
+        .param('height', 'The desired maximum height for the thumbnail.', paramType='query',
+               required=False, default=256)
         .errorResponse('ID was invalid.')
     )
     @access.cookie
@@ -248,7 +250,8 @@ class ImageResource(IsicResource):
         ImageItem = self.model('image_item', 'large_image')
 
         width = int(params.get('width', 256))
-        thumbData, thumbMime = ImageItem.getThumbnail(image, width=width)
+        height = int(params.get('height', 256))
+        thumbData, thumbMime = ImageItem.getThumbnail(image, width=width, height=height)
 
         # Only setRawResponse now, as this handler may return a JSON error
         # earlier

--- a/web_external/ImagesGallery/ImagesView.js
+++ b/web_external/ImagesGallery/ImagesView.js
@@ -44,7 +44,7 @@ const ImagesView = View.extend({
         // This will self-render when this.images updates
         this.imageWall = new ImageWall({
             images: this.images,
-            el: this.$('#isic-images-imageWall'),
+            el: this.$('.isic-images-imageWall'),
             parentView: this
         });
 

--- a/web_external/ImagesGallery/Listing/ImageWall.js
+++ b/web_external/ImagesGallery/Listing/ImageWall.js
@@ -4,10 +4,13 @@ import ImageFullscreenWidget from '../../common/Viewer/ImageFullscreenWidget';
 import View from '../../view';
 
 import ImageWallTemplate from './imageWall.pug';
+import './imageWall.styl';
 
 const ImageWall = View.extend({
+    className: 'isic-images-imageWall',
+
     events: {
-        'click .thumb': function (event) {
+        'click .isic-images-imageWall-thumbnail': function (event) {
             let imageId = $(event.currentTarget).data('imageId');
             let clickedImage = this.images.get(imageId);
 
@@ -45,12 +48,13 @@ const ImageWall = View.extend({
         this.$el.html(ImageWallTemplate({
             apiRoot: this.apiRoot,
             images: this.images,
-            thumbnailSize: this.thumbnailSize
+            thumbnailHeight: this.thumbnailSize * 0.75,
+            thumbnailWidth: this.thumbnailSize
         }));
 
         this.$('[data-toggle="tooltip"]').tooltip({
             placement: 'auto',
-            viewport: '#isic-images-imageWall',
+            viewport: this.$el,
             trigger: 'hover'
         });
 
@@ -58,11 +62,11 @@ const ImageWall = View.extend({
     },
 
     _rerenderSelection: function () {
-        this.$('.thumb').removeClass('selected');
+        this.$('.isic-images-imageWall-thumbnail').removeClass('selected');
 
         let selectedImage = this.images.selected;
         if (selectedImage) {
-            this.$(`.thumb[data-image-id="${selectedImage.id}"]`).addClass('selected');
+            this.$(`.isic-images-imageWall-thumbnail[data-image-id="${selectedImage.id}"]`).addClass('selected');
         }
     },
 

--- a/web_external/ImagesGallery/Listing/imageWall.pug
+++ b/web_external/ImagesGallery/Listing/imageWall.pug
@@ -1,8 +1,8 @@
 for image in images.toArray()
-  img.thumb(
-    src=`${apiRoot}/image/${image.id}/thumbnail?width=${thumbnailSize}`,
-    height=thumbnailSize * 0.75,
-    width=thumbnailSize,
-    data-image-id=image.id,
-    data-toggle='tooltip',
-    title=image.name())
+  .isic-images-imageWall-thumbnail(
+      data-image-id=image.id,
+      data-toggle='tooltip',
+      title=image.name())
+    div(style=`height:${thumbnailHeight}px;width:${thumbnailWidth}px;`)
+      img(
+        src=`${apiRoot}/image/${image.id}/thumbnail?height=${thumbnailHeight}&width=${thumbnailWidth}`)

--- a/web_external/ImagesGallery/Listing/imageWall.styl
+++ b/web_external/ImagesGallery/Listing/imageWall.styl
@@ -1,0 +1,35 @@
+.isic-images-imageWall
+  overflow-y auto
+  overflow-x hidden
+  min-width 32em
+
+  user-select none
+
+  // pack all lines together; separation will be via padding
+  line-height 0
+
+  .isic-images-imageWall-thumbnail
+    // inline-block ensures this will expend to the size of its content
+    display inline-block
+
+    padding 3px
+
+    &.selected
+      padding 0
+      border solid 3px deepskyblue
+
+    div
+      // inline-block forces this to respect inlined height and width
+      display inline-block
+      // nothing substantive should be hidden, but this will trim images to be pixel-perfect sizes
+      overflow hidden
+      // relative allows child blocks to position absolutly
+      position relative
+
+      img
+        // absolute allows top / transform to work
+        position absolute
+        // center image vertically and horizontally
+        left 50%
+        top 50%
+        transform translate(-50%, -50%)

--- a/web_external/ImagesGallery/imagesPage.pug
+++ b/web_external/ImagesGallery/imagesPage.pug
@@ -3,5 +3,5 @@
   .growing.flexColumn
     #isic-images-pagingPane.pane.flexRow
     .growing.flexRow.isic-images-image-container
-      #isic-images-imageWall.pane.growing
+      .isic-images-imageWall.pane.growing
       #isic-images-imageDetailsPane.fixedWidth.pane

--- a/web_external/ImagesGallery/imagesPage.styl
+++ b/web_external/ImagesGallery/imagesPage.styl
@@ -64,17 +64,3 @@
 
   .isic-images-image-container
     overflow auto
-
-    #isic-images-imageWall
-      overflow-y auto
-      overflow-x hidden
-      min-width 32em
-
-      user-select none
-
-    .thumb
-      padding 3px
-
-      &.selected
-        padding 0
-        border solid 3px deepskyblue


### PR DESCRIPTION
This rebuilds a lot of the logic for thumbnail layout.
* Vertically-oriented thumbnails (aspect ratio where width < height) will now be sized correctly, and not stretched.
* Thumbnail images will now *actually* have a width of `ImageWall.thumbnailSize` (`128` for now).
* Thumbnails will be vertically and horizontally centered within their boxes.
* Whitespace between thumbnails has been cleaned up to be closer to a pixel-perfect `6px`.