### PR TITLE
Metadata: Show warnings for unrecognized fields

### DIFF
--- a/plugin_tests/image_metadata_test.py
+++ b/plugin_tests/image_metadata_test.py
@@ -925,7 +925,7 @@ class ImageMetadataTestCase(base.TestCase):
         image = self._createImage()
         image['meta']['clinical']['sex'] = 'female'
         image['meta']['unstructured']['laterality'] = 'left'
-        errors, unrecognizedFields = addImageClinicalMetadata(image, data)
+        errors, warnings = addImageClinicalMetadata(image, data)
         self.assertEquals([], errors)
         self.assertDictEqual({
             'anatom_site_general': 'head',
@@ -946,10 +946,13 @@ class ImageMetadataTestCase(base.TestCase):
         self.assertDictEqual({
             'age': 45
         }, image['privateMeta'])
-        self.assertIsNotNone(unrecognizedFields)
-        self.assertEquals(2, len(unrecognizedFields))
-        self.assertIn('anatomic', unrecognizedFields)
-        self.assertIn('anatom_site_general', unrecognizedFields)
+        self.assertEquals(2, len(warnings))
+        self.assertIn(
+            "unrecognized field 'anatomic' will be added to unstructured metadata",
+            warnings)
+        self.assertIn(
+            "unrecognized field 'anatom_site_general' will be added to unstructured metadata",
+            warnings)
 
         # Data with errors
         data = {
@@ -969,7 +972,7 @@ class ImageMetadataTestCase(base.TestCase):
         image = self._createImage()
         image['meta']['clinical']['sex'] = 'male'
         image['meta']['clinical']['melanocytic'] = False
-        errors, unrecognizedFields = addImageClinicalMetadata(image, data)
+        errors, warnings = addImageClinicalMetadata(image, data)
         self.assertEquals(4, len(errors))
         self.assertIn(
             "value already exists for field 'sex' (old: 'male', new: 'female')",
@@ -985,4 +988,4 @@ class ImageMetadataTestCase(base.TestCase):
             "only one of field 'benign_malignant' may be present, "
             "found: ['ben_mal', 'benign_malignant']",
             errors)
-        self.assertIsNone(unrecognizedFields)
+        self.assertEquals([], warnings)

--- a/server/api/dataset.py
+++ b/server/api/dataset.py
@@ -325,7 +325,9 @@ class DatasetResource(IsicResource):
         user = self.getCurrentUser()
         User.requireCreateDataset(user)
 
-        errors = Dataset.applyMetadata(dataset=dataset, metadataFile=metadataFile, save=save)
+        errors, warnings = Dataset.applyMetadata(
+            dataset=dataset, metadataFile=metadataFile, save=save)
         return {
-            'errors': [{'description': description} for description in errors]
+            'errors': [{'description': description} for description in errors],
+            'warnings': [{'description': description} for description in warnings]
         }

--- a/server/models/dataset_helpers/image_metadata.py
+++ b/server/models/dataset_helpers/image_metadata.py
@@ -472,20 +472,21 @@ def addImageClinicalMetadata(image, data):
     Returns a tuple of:
     - List of descriptive errors with the metadata. An empty list indicates that
       there are no errors.
-    - Dictionary view object of unrecognized field names. To avoid erroneous
-      entries, this is populated only when there are no errors.
+    - List of warnings about the metadata. To avoid erroneous entries, this is
+      populated only when there are no errors.
 
     :param image: The image.
     :type image: dict
     :param data: The image metadata.
     :type data: dict
-    :return: Tuple of (errors with the metadata, unrecognized field names)
-    :rtype: tuple(list of strings, dictionary view object or None)
+    :return: Tuple of (errors, warnings)
+    :rtype: tuple(list of strings, list of strings)
     """
     # Operate on copy of image metadata
     data = copy.deepcopy(data)
 
     errors = []
+    warnings = []
 
     for parser in [
         AgeFieldParser,
@@ -522,7 +523,10 @@ def addImageClinicalMetadata(image, data):
     # Add remaining data as unstructured metadata
     image['meta']['unstructured'].update(data)
 
-    # Report unrecognized fields when there are no errors
-    unrecognizedFields = six.viewkeys(data) if not errors else None
+    # Report warnings for unrecognized fields when there are no errors
+    if not errors:
+        warnings = [
+            'unrecognized field %r will be added to unstructured metadata' % (field)
+            for field in data]
 
-    return errors, unrecognizedFields
+    return errors, warnings

--- a/server/models/dataset_helpers/image_metadata.py
+++ b/server/models/dataset_helpers/image_metadata.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import copy
 import six
 
 
@@ -481,6 +482,9 @@ def addImageClinicalMetadata(image, data):
     :return: Tuple of (errors with the metadata, unrecognized field names)
     :rtype: tuple(list of strings, dictionary view object or None)
     """
+    # Operate on copy of image metadata
+    data = copy.deepcopy(data)
+
     errors = []
 
     for parser in [

--- a/server/models/dataset_helpers/image_metadata.py
+++ b/server/models/dataset_helpers/image_metadata.py
@@ -468,15 +468,18 @@ def addImageClinicalMetadata(image, data):
     image's clinical metadata field and private metadata field. Unrecognized
     fields are added to the image's unstructured metadata field.
 
-    Returns a list of descriptive errors with the metadata. An empty list
-    indicates that there are no errors.
+    Returns a tuple of:
+    - List of descriptive errors with the metadata. An empty list indicates that
+      there are no errors.
+    - Dictionary view object of unrecognized field names. To avoid erroneous
+      entries, this is populated only when there are no errors.
 
     :param image: The image.
     :type image: dict
     :param data: The image metadata.
     :type data: dict
-    :return: List of errors with the metadata.
-    :rtype: list of strings
+    :return: Tuple of (errors with the metadata, unrecognized field names)
+    :rtype: tuple(list of strings, dictionary view object or None)
     """
     errors = []
 
@@ -515,4 +518,7 @@ def addImageClinicalMetadata(image, data):
     # Add remaining data as unstructured metadata
     image['meta']['unstructured'].update(data)
 
-    return errors
+    # Report unrecognized fields when there are no errors
+    unrecognizedFields = six.viewkeys(data) if not errors else None
+
+    return errors, unrecognizedFields

--- a/web_external/Datasets/ApplyMetadataView.js
+++ b/web_external/Datasets/ApplyMetadataView.js
@@ -62,14 +62,17 @@ const MetadataResultModel = Backbone.Model.extend({
 // should be set to the name of the field to parse in the response from the server.
 // The list of items in the collection is meaningful only when initialized() is true.
 const MetadataResultModelCollection = Backbone.Collection.extend({
+    initialize: function (models, options) {
+        this._field = options.field;
+    },
+
     model: MetadataResultModel,
-    field: null,
 
     _initialized: false,
 
     parse: function (resp) {
         this._initialized = true;
-        return resp[this.field];
+        return resp[this._field];
     },
 
     initialized: function () {
@@ -177,10 +180,8 @@ const ApplyMetadataView = View.extend({
         this.file = null;
 
         // Errors and warnings in the selected metadata file
-        this.errors = new MetadataResultModelCollection();
-        this.errors.field = 'errors';
-        this.warnings = new MetadataResultModelCollection();
-        this.warnings.field = 'warnings';
+        this.errors = new MetadataResultModelCollection(null, {'field': 'errors'});
+        this.warnings = new MetadataResultModelCollection(null, {'field': 'warnings'});
 
         this.selectFileView = new ApplyMetadataSelectFileView({
             collection: this.files,

--- a/web_external/Datasets/applyMetadataValidationPage.pug
+++ b/web_external/Datasets/applyMetadataValidationPage.pug
@@ -1,21 +1,34 @@
 if errors.initialized()
   h3 Results
   - let hasErrors = !errors.isEmpty()
+  - let hasWarnings = !warnings.isEmpty()
   .isic-apply-metadata-validation-result-header(
     class=hasErrors ? 'isic-apply-metadata-validation-result-header-error' : 'isic-apply-metadata-validation-result-header-ok')
     .isic-apply-metadata-validation-result-header-filename
       = file.name()
     .isic-apply-metadata-validation-result-header-status
-      if !hasErrors
+      if !hasErrors && !hasWarnings
+        .isic-apply-metadata-validation-result-header-status-ok
         | OK&nbsp;
         i.icon-ok
       else
-        = errors.length
-        if errors.length > 1
-          |  Errors&nbsp;
-        else
-          |  Error&nbsp;
-        i.icon-attention
+        .isic-apply-metadata-validation-result-header-status-bad
+          if hasErrors
+            = errors.length
+            if errors.length > 1
+              |  errors
+            else
+              |  error
+          if hasWarnings
+            if hasErrors
+              | ,&nbsp;
+            | #{warnings.length}
+            if warnings.length > 1
+              |  warnings
+            else
+              |  warning
+          | &nbsp;
+          i.icon-attention
   if hasErrors
     .isic-apply-metadata-validation-result-content
       .isic-apply-metadata-validation-result-error-header
@@ -24,3 +37,11 @@ if errors.initialized()
         ul
           each error in errors.toArray()
             li= error.description()
+  if hasWarnings
+    .isic-apply-metadata-validation-result-content
+      .isic-apply-metadata-validation-result-error-header
+        | Warnings:
+      .isic-apply-metadata-validation-result-error-content
+        ul
+          each warning in warnings.toArray()
+            li= warning.description()

--- a/web_external/Datasets/applyMetadataValidationPage.styl
+++ b/web_external/Datasets/applyMetadataValidationPage.styl
@@ -10,8 +10,12 @@
 
   .isic-apply-metadata-validation-result-header-filename
     flex 1
+    margin-right 15px
   .isic-apply-metadata-validation-result-header-status
     background-color clear
+
+    .isic-apply-metadata-validation-result-header-status-bad
+      font-style italic
 
 .isic-apply-metadata-validation-result-content
   background-color #ffffe0


### PR DESCRIPTION
When applying metadata to a dataset, show warnings for fields that
weren't recognized and will be added to unstructured metadata.