### PR TITLE
Allow extra images in metadata CSV file

### DIFF
--- a/plugin_tests/upload_test.py
+++ b/plugin_tests/upload_test.py
@@ -346,10 +346,16 @@ class UploadTestCase(IsicTestCase):
             })
         self.assertStatusOk(resp)
         self.assertIn('errors', resp.json)
+        self.assertIn('warnings', resp.json)
+        self.assertEqual([], resp.json['errors'])
         self.assertEqual(
-            resp.json['errors'], [
-                {u'description':
-                 u'on CSV row 4: no images found that match "filename": "test_1_small_3.jpg"'},
-                {u'description':
-                 u'on CSV row 6: no images found that match "filename": "test_1_large_2.jpg"'}
+            resp.json['warnings'], [
+                {'description':
+                 'on CSV row 4: no images found that match "filename": "test_1_small_3.jpg"'},
+                {'description':
+                 'on CSV row 6: no images found that match "filename": "test_1_large_2.jpg"'},
+                {'description':
+                 'unrecognized field \'age_approx\' will be added to unstructured metadata'},
+                {'description':
+                 'unrecognized field \'isic_source_name\' will be added to unstructured metadata'}
             ])

--- a/plugin_tests/upload_test.py
+++ b/plugin_tests/upload_test.py
@@ -351,9 +351,9 @@ class UploadTestCase(IsicTestCase):
         self.assertEqual(
             resp.json['warnings'], [
                 {'description':
-                 'on CSV row 4: no images found that match "filename": "test_1_small_3.jpg"'},
+                 'on CSV row 4: no images found that match \'filename\': \'test_1_small_3.jpg\''},
                 {'description':
-                 'on CSV row 6: no images found that match "filename": "test_1_large_2.jpg"'},
+                 'on CSV row 6: no images found that match \'filename\': \'test_1_large_2.jpg\''},
                 {'description':
                  'unrecognized field \'age_approx\' will be added to unstructured metadata'},
                 {'description':

--- a/server/models/dataset.py
+++ b/server/models/dataset.py
@@ -419,7 +419,7 @@ class Dataset(FolderModel):
             isicIdField = None
         if (not originalNameField) and (not isicIdField):
             raise FileMetadataException(
-                'no "filename" or "isic_id" field found in CSV')
+                'no \'filename\' or \'isic_id\' field found in CSV')
         return originalNameField, isicIdField
 
     def _getImageForMetadataCsvRow(self, dataset, csvRow, originalNameField,
@@ -456,13 +456,13 @@ class Dataset(FolderModel):
         numImages = images.count()
         if numImages != 1:
             if originalNameField and isicIdField:
-                errorStr = 'that match both "%s": "%s" and "%s": "%s"' % (
+                errorStr = 'that match both %r: %r and %r: %r' % (
                     originalNameField, originalName, isicIdField, isicId)
             elif originalNameField:
-                errorStr = 'that match "%s": "%s"' % (
+                errorStr = 'that match %r: %r' % (
                     originalNameField, originalName)
             else:  # isicIdField
-                errorStr = 'that match "%s": "%s"' % (
+                errorStr = 'that match %r: %r' % (
                     isicIdField, isicId)
 
             # No images found


### PR DESCRIPTION
When validating metadata, allow images to be defined in the CSV file that aren't in the database. Report these images as warnings. Previously these cases were reported as errors.

Fixes #448 