### PR TITLE
Use natural sorting for metadata warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 geojson>=1.3.2
 python-dateutil>=2.6.0
+natsort>=5.0.0
 numpy>=1.10.2
 
 Pillow==3.4.2

--- a/server/models/dataset.py
+++ b/server/models/dataset.py
@@ -22,6 +22,8 @@ import datetime
 import itertools
 import os
 
+from natsort import natsorted
+
 from girder.constants import AccessType
 from girder.models.folder import Folder as FolderModel
 from girder.models.model_base import GirderException, ValidationException
@@ -404,7 +406,7 @@ class Dataset(FolderModel):
             for image in images:
                 Image.save(image)
 
-        return metadataErrors, sorted(metadataWarnings)
+        return metadataErrors, natsorted(metadataWarnings)
 
     def _getFilenameFields(self, csvReader):
         for originalNameField in csvReader.fieldnames:


### PR DESCRIPTION
Use natural sorting for metadata warnings instead of lexicographic
sorting. Because the warnings include CSV row numbers, natural sorting
ensures that the warnings appear in row order.

A dependency is added on a module that provides a natural sorting
algorithm [1].

[1] https://github.com/SethMMorton/natsort