### PR TITLE
Require metadata CSV to be UTF-8 encoded

### DIFF
--- a/plugin_tests/upload_test.py
+++ b/plugin_tests/upload_test.py
@@ -350,17 +350,17 @@ class UploadTestCase(IsicTestCase):
         self.assertEqual(
             resp.json['errors'], [
                 {'description':
-                 'on CSV row 5: values [\'solar lentigo\', False] for fields [\'diagnosis\', '
+                 'on CSV row 5: values [u\'solar lentigo\', False] for fields [\'diagnosis\', '
                  '\'melanocytic\'] are inconsistent'}
             ])
         self.assertEqual(
             resp.json['warnings'], [
                 {'description':
-                 'on CSV row 4: no images found that match \'filename\': \'test_1_small_3.jpg\''},
+                 'on CSV row 4: no images found that match u\'filename\': u\'test_1_small_3.jpg\''},
                 {'description':
-                 'on CSV row 6: no images found that match \'filename\': \'test_1_large_2.jpg\''},
+                 'on CSV row 6: no images found that match u\'filename\': u\'test_1_large_2.jpg\''},
                 {'description':
-                 'unrecognized field \'age_approx\' will be added to unstructured metadata'},
+                 'unrecognized field u\'age_approx\' will be added to unstructured metadata'},
                 {'description':
-                 'unrecognized field \'isic_source_name\' will be added to unstructured metadata'}
+                 'unrecognized field u\'isic_source_name\' will be added to unstructured metadata'}
             ])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backports.csv>=1.0.5
 geojson>=1.3.2
 python-dateutil>=2.6.0
 numpy>=1.10.2

--- a/server/models/dataset.py
+++ b/server/models/dataset.py
@@ -17,7 +17,6 @@
 #  limitations under the License.
 ###############################################################################
 
-import csv
 import datetime
 import itertools
 import os
@@ -28,6 +27,7 @@ from girder.models.model_base import GirderException, ValidationException
 from girder.models.notification import ProgressState
 from girder.utility import assetstore_utilities, mail_utils
 from girder.utility.progress import ProgressContext
+from backports import csv
 
 from .dataset_helpers import matchFilenameRegex
 from .dataset_helpers.image_metadata import addImageMetadata
@@ -398,6 +398,9 @@ class Dataset(FolderModel):
             metadataErrors.append(str(e))
         except csv.Error as e:
             metadataErrors.append('parsing CSV: %s' % str(e))
+        except UnicodeDecodeError as e:
+            metadataErrors.append('CSV is not UTF-8 encoded (%s at position %d in %r)' %
+                                  (e.reason, e.start, e.object))
 
         # Save updated metadata to images
         if not metadataErrors and save:

--- a/server/utility/__init__.py
+++ b/server/utility/__init__.py
@@ -20,8 +20,9 @@
 
 def generateLines(stream):
     """
-    Generate individual lines of text from a stream. Newlines are retained in
-    the output.
+    Generate individual unicode lines of text from a stream. Newlines are
+    retained in the output. Decoding using 'utf-8-sig' removes Unicode BOM
+    (byte order mark).
     """
     lastLine = None
     keepends = True
@@ -36,8 +37,8 @@ def generateLines(stream):
             lines = chunk.splitlines(keepends)
             lastLine = lines.pop()
             for line in lines:
-                yield line
+                yield unicode(line, 'utf-8-sig')
     except StopIteration:
         if lastLine is not None:
-            yield lastLine
+            yield unicode(lastLine, 'utf-8-sig')
         raise StopIteration


### PR DESCRIPTION
Require metadata CSV files to be UTF-8 encoded. Validation of CSV files
that aren't UTF-8 encoded will indicate an error that provides details
of the first encoding problem encountered in the file.

Because MongoDB stores data in BSON format and BSON strings are UTF-8
encoded, strings stored to the database must contain valid UTF-8 data
[1]. Validating that the CSV file is UTF-8 encoded avoids errors when
saving strings to the database later in the workflow. For example:

    InvalidStringData: strings in documents must be valid UTF-8

The implementation replaces the csv module with a backport of Python 3's
csv module [2]. This ensures that csv.DictReader properly reads UTF-8
CSV files and returns Unicode strings. Additionally, using this backport
instead of managing UTF-8 conversions manually should make a future
transition to Python 3 easier.

Note that the implementation currently isn't compatible with Python 3
because of the use of the unicode() function.

[1] http://api.mongodb.com/python/current/tutorial.html#a-note-on-unicode-strings
[2] https://github.com/ryanhiebert/backports.csv

Fixes #473 