### PR TITLE
Fix CI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,9 @@ jobs:
       - run:
           name: Create cache key
           command: cat girder/setup.py girder/requirements-dev.txt girder_worker/setup.py girder/plugins/large_image/setup.py girder/plugins/isic_archive/requirements.txt | sha512sum > venv-req-hash.txt
-      - restore_cache:
-          key: venv-{{ arch }}-{{ checksum "venv-req-hash.txt" }}
+      #- restore_cache:
+      # TODO: caching is broken, because "girder/requirements-dev.txt" requires exactly "pbr==1.10.0", and "girder_worker/setup.py" requires a newer version; however installing fresh every time still works
+      #    key: venv-{{ arch }}-{{ checksum "venv-req-hash.txt" }}
       - run:
           name: Install Girder
           command: |
@@ -83,9 +84,9 @@ jobs:
       - run:
           name: Install coverage client
           command: pip install codecov
-      - save_cache:
-          paths: venv
-          key: venv-{{ arch }}-{{ checksum "venv-req-hash.txt" }}
+      #- save_cache:
+      #    paths: venv
+      #    key: venv-{{ arch }}-{{ checksum "venv-req-hash.txt" }}
 
       - restore_cache:
           key: npm-{{ arch }}-{{ checksum "girder/package.json" }}-{{ checksum "girder/plugins/isic_archive/plugin.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           name: Create cache key
           command: cat girder/setup.py girder/requirements-dev.txt girder_worker/setup.py girder/plugins/large_image/setup.py girder/plugins/isic_archive/requirements.txt | sha512sum > venv-req-hash.txt
       - restore_cache:
-          key: venv-{{ checksum "venv-req-hash.txt" }}
+          key: venv-{{ arch }}-{{ checksum "venv-req-hash.txt" }}
       - run:
           name: Install Girder
           command: |
@@ -85,12 +85,10 @@ jobs:
           command: pip install codecov
       - save_cache:
           paths: venv
-          key: venv-{{ checksum "venv-req-hash.txt" }}
+          key: venv-{{ arch }}-{{ checksum "venv-req-hash.txt" }}
 
       - restore_cache:
-          # TODO: "girder/package.json" is getting modified during the build
-          # key: npm-{{ checksum "girder/package.json" }}-{{ checksum "girder/plugins/isic_archive/plugin.json" }}
-          key: npm-girder2.2.0-{{ checksum "girder/plugins/isic_archive/plugin.json" }}
+          key: npm-{{ arch }}-{{ checksum "girder/package.json" }}-{{ checksum "girder/plugins/isic_archive/plugin.json" }}
       - run:
           name: Build Girder web client
           command: girder-install web --dev --plugins=isic_archive
@@ -98,8 +96,7 @@ jobs:
             - npm_config_cache: /home/circleci/project/npm_cache
       - save_cache:
           paths: npm_cache
-          # key: npm-{{ checksum "girder/package.json" }}-{{ checksum "girder/plugins/isic_archive/plugin.json" }}
-          key: npm-girder2.2.0-{{ checksum "girder/plugins/isic_archive/plugin.json" }}
+          key: npm-{{ arch }}-{{ checksum "girder/package.json" }}-{{ checksum "girder/plugins/isic_archive/plugin.json" }}
 
       - run:
           name: Create Girder build directory


### PR DESCRIPTION
This fixes the build bugs we've been seeing. However, caching of Python packages is now disabled, until an upstream dependency conflict can be fixed.