### PR TITLE
Fix histogram ordinal bin label formatting

### DIFF
--- a/web_external/ImagesGallery/Facets/ImagesFacetView.js
+++ b/web_external/ImagesGallery/Facets/ImagesFacetView.js
@@ -89,7 +89,8 @@ const ImagesFacetView = View.extend({
         if (completeBin.label === '__null__') {
             return 'unknown';
         } else if (_.has(completeBin, 'lowBound')) {
-            let formatter = d3.format('0.3s');
+            // Decimal notation, rounded to significant digits
+            let formatter = d3.format('0.3r');
             let lowBracket = completeBin.label[0];
             let highBracket = completeBin.label[completeBin.label.length - 1];
             let lowBound = formatter(completeBin.lowBound);


### PR DESCRIPTION
The 's' type used in d3.format() specifies "decimal notation with an SI prefix, rounded to significant digits." This formatter converts "0.5" to "500m", which is not the desired behavior.

Use the 'r' type instead, which specifies "decimal notation, rounded to significant digits."

An alternative would be to use the ' ' (space) type, which trims insignificant trailing zeros.

See https://github.com/d3/d3-format#api-reference.