### PR TITLE
Don't attempt to send email to an empty list of addresses

### DIFF
--- a/server/api/user.py
+++ b/server/api/user.py
@@ -107,18 +107,19 @@ def requestCreateDatasetPermission(self, params):
                 for user in groupAcl['users']
                 if user['level'] >= AccessType.WRITE
             ]
-            host = mail_utils.getEmailUrlPrefix()
-            html = mail_utils.renderTemplate(
-                'datasetContributorRequest.mako',
-                {
-                    'user': currentUser,
-                    'group': group,
-                    'host': host,
-                })
-            mail_utils.sendEmail(
-                to=groupModeratorEmails,
-                subject='ISIC Archive: Dataset Contributor Request',
-                text=html)
+            if groupModeratorEmails:
+                host = mail_utils.getEmailUrlPrefix()
+                html = mail_utils.renderTemplate(
+                    'datasetContributorRequest.mako',
+                    {
+                        'user': currentUser,
+                        'group': group,
+                        'host': host,
+                    })
+                mail_utils.sendEmail(
+                    to=groupModeratorEmails,
+                    subject='ISIC Archive: Dataset Contributor Request',
+                    text=html)
 
     return resp
 


### PR DESCRIPTION
When a user requests permission to create a dataset the moderators and
administrators of the 'Dataset Contributors' group receive an email.
When the group has no moderators or administrators, such as on a newly
provisioned deployment, the sendEmail() function throws an exception.

To avoid the exception, add a check that the list of email addresses is
not empty before attempting to send email.

Fixes #491 