### PR TITLE
Ansible: Fix installing MongoDB

### DIFF
--- a/ansible/roles/mongodb/tasks/main.yml
+++ b/ansible/roles/mongodb/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Add PPA key
   apt_key:
-    id: "0C49F3730359A14518585931BC711F9BA15703C6"
+    id: "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
     keyserver: "keyserver.ubuntu.com"
   become: yes
 


### PR DESCRIPTION
Update the public key used to authenticate the MongoDB packages to the
key used to sign the 3.6 release. This fixes the following error during
the "mongodb : Install package" task during Ansible provisioning:

    There were unauthenticated packages and -y was used without --allow-unauthenticated