### PR TITLE
Metadata: Autocorrect melanocytic field inconsistencies

### DIFF
--- a/plugin_tests/upload_test.py
+++ b/plugin_tests/upload_test.py
@@ -367,14 +367,12 @@ class UploadTestCase(IsicTestCase):
         self.assertStatusOk(resp)
         self.assertIn('errors', resp.json)
         self.assertIn('warnings', resp.json)
-        self.assertEqual(
-            resp.json['errors'], [
-                {'description':
-                 'on CSV row 5: values [u\'solar lentigo\', False] for fields [\'diagnosis\', '
-                 '\'melanocytic\'] are inconsistent'}
-            ])
+        self.assertEqual(0, len(resp.json['errors']))
         self.assertEqual(
             resp.json['warnings'], [
+                {'description':
+                 'corrected inconsistent value for field \'melanocytic\' based on field '
+                 '\'diagnosis\' (new value: True, \'diagnosis\': u\'solar lentigo\')'},
                 {'description':
                  'on CSV row 4: no images found that match u\'filename\': u\'test_1_small_3.jpg\''},
                 {'description':


### PR DESCRIPTION
Validation failures for the melanocytic field with respect to the diagnosis field are now autocorrected and a warning is generated.

Note that the metadata logic still prevents existing non-null melanocytic values from being overwritten.

Fixes #524 