### PR TITLE
Solar lentigo is no longer considered melanocytic

### DIFF
--- a/plugin_tests/upload_test.py
+++ b/plugin_tests/upload_test.py
@@ -371,9 +371,6 @@ class UploadTestCase(IsicTestCase):
         self.assertEqual(
             resp.json['warnings'], [
                 {'description':
-                 'corrected inconsistent value for field \'melanocytic\' based on field '
-                 '\'diagnosis\' (new value: True, \'diagnosis\': u\'solar lentigo\')'},
-                {'description':
                  'on CSV row 4: no images found that match u\'filename\': u\'test_1_small_3.jpg\''},
                 {'description':
                  'on CSV row 6: no images found that match u\'filename\': u\'test_1_large_2.jpg\''},

--- a/server/models/dataset_helpers/image_metadata.py
+++ b/server/models/dataset_helpers/image_metadata.py
@@ -325,7 +325,6 @@ class MelanocyticFieldParser(FieldParser):
         'nevus',
         'nevus spilus',
         'atypical melanocytic proliferation',
-        'solar lentigo',
         'lentigo simplex',
         'lentigo NOS',
     ]


### PR DESCRIPTION
This updates metadata validation. The database metadata should be updated separately.