### PR TITLE
Upgrade Girder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
 
     environment:
-      - GIRDER_VERSION: ffc49c0c5f92b4b4372512b015d24e83c4f4ef47
+      - GIRDER_VERSION: 51c59c97d28aacaa042ee5bbb55f3547e8de5a20
       - WORKER_VERSION: 042a69d6ae7d472e32242d98f8b7acb3148980f9
       - LARGE_IMAGE_VERSION: 4dc82976d58b2a6e6542863e2e410628649a040c
 

--- a/ansible/roles/isic/vars/main.yml
+++ b/ansible/roles/isic/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 
-girder_version: "ffc49c0c5f92b4b4372512b015d24e83c4f4ef47"
+girder_version: "51c59c97d28aacaa042ee5bbb55f3547e8de5a20"
 worker_version: "042a69d6ae7d472e32242d98f8b7acb3148980f9"
 python_dist_path: "{{ ansible_user_dir }}/env"
 large_image_version: "4dc82976d58b2a6e6542863e2e410628649a040c"


### PR DESCRIPTION
List of changes:
```
$ git shortlog ffc49c0..51c59c9 --no-merges
Brian Helba (8):
      pydicom has renamed the importable library to "pydicom", from "dicom"
      Update code to use the pydicom 1.0 API
      Modify setup.py, to ensure the CircleCI Python package cache is flushed
      Move CLI commands to a "cli" module
      Deprecate legacy "python -m ..." methods for starting Girder
      Don't use warnings.warn for runtime server code
      Document a coverage exclusion policy for Python code
      Ensure that CLI deprecation warnings are always printed

David Manthey (10):
      Initial FUSE plugin.
      Return more sensible file and directory permissions.
      Explicitly throw an error on the create operation.
      Update to modern girder conventions.
      Move some variables to the private namespace.
      Move startFromConfig call into load function.
      Improve tests, errors, and docs.
      Harden fuse test.
      Fix a typo, add 'read-only' to the docs, add a changelog entry.
      Fix a typo in the plugins doc.

Jonathan Beezley (2):
      Support virtual domain syntax in s3 assetstore test
      Remove symlinked file to fix pip upgrade

Max Smolens (1):
      Make build type available to front-end code
```

Fixes https://github.com/ImageMarkup/isic-archive/issues/533