### PR TITLE
Separate annotation responses and markups

### DIFF
--- a/custom/phase2.html
+++ b/custom/phase2.html
@@ -93,24 +93,24 @@
                     <div class="isic-annotation-body">
                         <uib-accordion close-others="false">
                             <uib-accordion-group
-                                        ng-repeat="feature in featureset.globalFeatures track by feature.id"
-                                        heading="{{ feature.name.join(': ') }}"
+                                        ng-repeat="question in featureset.globalFeatures track by question.id"
+                                        heading="{{ question.name.join(': ') }}"
                                         is-open="true">
                                 <div ng-show="!showReview">
-                                    <div ng-repeat="feature_option in feature.options track by feature_option.id">
-                                        <label class="isic-annotation-feature-option"
-                                               ng-class="{selected: feature_option.id === annotation_values[feature.id]}">
+                                    <div ng-repeat="questionOption in question.options track by questionOption.id">
+                                        <label class="isic-annotation-question-option"
+                                               ng-class="{selected: questionOption.id === responses[question.id]}">
                                             <input
                                                     type="radio"
-                                                    ng-model="annotation_values[feature.id]"
-                                                    name="{{ feature.id }}"
-                                                    value="{{ feature_option.id }}">
-                                            {{ feature_option.name }}
+                                                    ng-model="responses[question.id]"
+                                                    name="{{ question.id }}"
+                                                    value="{{ questionOption.id }}">
+                                            {{ questionOption.name }}
                                         </label>
                                     </div>
                                 </div>
                                 <div ng-show="showReview">
-                                    <label class="isic-annotation-feature-option selected">{{ feature_selected_option_name(feature) }}</label>
+                                    <label class="isic-annotation-question-option selected">{{ selectedResponseName(question) }}</label>
                                 </div>
                             </uib-accordion-group>
                         </uib-accordion>

--- a/custom/static/css/isic-phase2.css
+++ b/custom/static/css/isic-phase2.css
@@ -48,10 +48,10 @@
     display: inline-block;
 }
 
-.isic-annotation-feature-option {
+.isic-annotation-question-option {
     font-weight: 300;
 }
-.isic-annotation-feature-option.selected {
+.isic-annotation-question-option.selected {
     font-weight: 700;
     color: #ffcc00;
 }

--- a/custom/static/js/isic-phase2.js
+++ b/custom/static/js/isic-phase2.js
@@ -26,11 +26,13 @@ derm_app.controller('AnnotationController', [
     'Annotation', 'Study', 'Featureset', 'Image',
     function ($scope, $rootScope, $location, $http,
               Annotation, Study, Featureset, Image) {
-        $scope.annotation_values = {};
+        $scope.responses = {};
+        $scope.markups = {};
         $scope.clearAnnotations = function () {
-            // annotation_values should be set before initialization,
+            // responses and markups should be set before initialization,
             //   but must also be re-cleared after child controllers run
-            $scope.annotation_values = {};
+            $scope.responses = {};
+            $scope.markups = {};
             $scope.$broadcast('reset');
             $scope.showReview = false;
         };
@@ -87,7 +89,8 @@ derm_app.controller('AnnotationController', [
                 imageId: $scope.image._id,
                 startTime: start_time,
                 stopTime: Date.now(),
-                annotations: $scope.annotation_values
+                responses: $scope.responses,
+                markups: $scope.markups
             };
             $http.put(submit_url, annotation_to_store).success(function () {
                 // window.location.replace('/#tasks');
@@ -112,16 +115,16 @@ derm_app.controller('GlobalFeatureAnnotationController', ['$scope',
             // TODO: reset drop-downs
         });
 
-        $scope.feature_selected_option_name = function (feature) {
-            var selected_option_id = $scope.annotation_values[feature.id];
-            var selected_option = feature.options.find(function (option) {
-                return option.id === selected_option_id;
+        $scope.selectedResponseName = function (question) {
+            var selectedResponseId = $scope.responses[question.id];
+            var selectedResponse = question.options.find(function (questionOption) {
+                return questionOption.id === selectedResponseId;
             });
-            return selected_option ? selected_option.name : '';
+            return selectedResponse ? selectedResponse.name : '';
         };
 
         $scope.selected = function () {
-            console.log('selected', $scope.annotation_values);
+            console.log('selected', $scope.responses);
         };
     }
 ]);
@@ -166,7 +169,7 @@ derm_app.controller('LocalFeatureAnnotationController', ['$scope', '$rootScope',
         $scope.activateFeature = function (featureId) {
             // store the previously active feature
             if ($scope.activeFeatureId) {
-                $scope.annotation_values[$scope.activeFeatureId] =
+                $scope.markups[$scope.activeFeatureId] =
                     $rootScope.pixelmap.getActiveValues();
             }
 
@@ -174,26 +177,26 @@ derm_app.controller('LocalFeatureAnnotationController', ['$scope', '$rootScope',
 
             if ($scope.activeFeatureId) {
                 $rootScope.pixelmap.activate(
-                    $scope.annotation_values[$scope.activeFeatureId]);
+                    $scope.markups[$scope.activeFeatureId]);
             } else {
                 $rootScope.pixelmap.clear();
             }
         };
 
         $scope.featureIsSet = function (featureId) {
-            return $scope.annotation_values[featureId] !== undefined;
+            return $scope.markups[featureId] !== undefined;
         };
 
         $scope.deleteFeature = function (featureId) {
             if ($scope.isActive(featureId)) {
                 $scope.activateFeature(null);
             }
-            delete $scope.annotation_values[featureId];
+            delete $scope.markups[featureId];
         };
 
         $scope.displayFeature = function (featureId) {
             if (featureId) {
-                $rootScope.pixelmap.display($scope.annotation_values[featureId]);
+                $rootScope.pixelmap.display($scope.markups[featureId]);
             } else {
                 $rootScope.pixelmap.clear();
             }

--- a/scripts/migrateAnnotation.py
+++ b/scripts/migrateAnnotation.py
@@ -1,27 +1,18 @@
 from girder.utility import server as girder_server
 girder_server.configureServer()
 
-from girder.models.item import Item  # noqa: E402
-from girder.models.folder import Folder  # noqa: E402
 from girder.plugins.isic_archive.models.annotation import Annotation  # noqa: E402
-from girder.plugins.isic_archive.models.study import Study  # noqa: E402
 
-for annotationItem in Item().find({
-    'baseParentId': Study().loadStudyCollection()['_id']
-}):
-    Annotation().save({
-        '_id': annotationItem['_id'],
-        'studyId': annotationItem['meta']['studyId'],
-        'imageId': annotationItem['meta']['imageId'],
-        'userId': annotationItem['meta']['userId'],
-        'startTime': annotationItem['meta'].get('startTime', None),
-        'stopTime': annotationItem['meta'].get('stopTime', None),
-        'status': annotationItem['meta'].get('status', None),
-        'annotations': annotationItem['meta'].get('annotations', None),
-    })
+for annotation in Annotation().find():
+    annotation['markups'] = {}
+    annotation['responses'] = {}
 
-for studyAnnotatorFolder in Folder().find({
-    'baseParentId': Study().loadStudyCollection()['_id'],
-    'meta.userId': {'$exists': 1}
-}):
-    Folder().remove(studyAnnotatorFolder)
+    markups = annotation.pop('annotations')
+    if markups is not None:
+        for markupName, markupValue in markups.items():
+            if isinstance(markupValue, list):
+                annotation['markups'][markupName] = markupValue
+            else:
+                annotation['responses'][markupName] = markupValue
+
+    Annotation().save(annotation, validate=False)

--- a/server/api/study.py
+++ b/server/api/study.py
@@ -23,7 +23,6 @@ import functools
 import itertools
 
 import cherrypy
-import six
 
 from girder.api import access
 from girder.api.rest import loadmodel, setResponseHeader
@@ -180,31 +179,13 @@ class StudyResource(IsicResource):
                 }
 
                 outDict = outDictBase.copy()
-                for globalFeature in featureset['globalFeatures']:
-                    if globalFeature['id'] in annotation['annotations']:
-                        outDict[globalFeature['id']] = \
-                            annotation['annotations'][globalFeature['id']]
+                for question in featureset['globalFeatures']:
+                    if question['id'] in annotation['responses']:
+                        outDict[question['id']] = annotation['responses'][question['id']]
                 csvWriter.writerow(outDict)
                 yield responseBody.getvalue()
                 responseBody.seek(0)
                 responseBody.truncate()
-
-                # TODO: move this into the query
-                if 'localFeatures' in annotation['annotations']:
-                    superpixelCount = len(next(six.viewvalues(
-                        annotation['annotations']['localFeatures'])))
-                    for superpixelMum in xrange(superpixelCount):
-
-                        outDict = outDictBase.copy()
-                        outDict['superpixel_id'] = superpixelMum
-                        for featureName, featureValue in six.viewitems(
-                                annotation['annotations']['localFeatures']):
-                            outDict[featureName] = featureValue[superpixelMum]
-
-                        csvWriter.writerow(outDict)
-                        yield responseBody.getvalue()
-                        responseBody.seek(0)
-                        responseBody.truncate()
 
     @describeRoute(
         Description('Create an annotation study.')

--- a/web_external/StudyResults/StudyResultsView.js
+++ b/web_external/StudyResults/StudyResultsView.js
@@ -389,7 +389,7 @@ const StudyResultsGlobalFeaturesView = View.extend({
 
     updateResults: function () {
         this.results.update(
-            this.annotation.get('annotations'),
+            this.annotation.get('responses'),
             this.featureset.get('globalFeatures')
         );
     }
@@ -501,11 +501,11 @@ const StudyResultsLocalFeaturesView = View.extend({
     },
 
     featureAnnotated: function (featureId) {
-        if (!featureId || !this.annotation.has('annotations')) {
+        if (!featureId || !this.annotation.has('markups')) {
             return false;
         }
-        let annotations = this.annotation.get('annotations');
-        return _.has(annotations, featureId);
+        let markups = this.annotation.get('markups');
+        return _.has(markups, featureId);
     }
 });
 


### PR DESCRIPTION
https://github.com/ImageMarkup/isic-archive/wiki/Annotation provides the model for this change.

This will require another database migration, which is included.

This updates the `PUT /annotation/:annotationId` API in an incompatible way, as that's not used publicly. The annotation client is updated accordingly.

This renames other annotation-related APIs, deprecating the old names:
* get the markup as a PNG mask:
  * old: `GET /annotation/:annotationId/:featureId/mask`
  * new: `GET /annotation/:annotationId/markup/:featureId`
  * note, this is now the preferred way to get markup, as it will be generalizable to non-superpixel markup and does not require any special superpixel knowledge or masks
* get the markup as a rendered JPEG overlay on the image:
  * old: `GET /annotation/:annotationId/:featureId/render`
  * new: `GET /annotation/:annotationId/markup/:featureId/rendered`
* get the markup raw superpixels as JSON:
  * old: `GET /annotation/:annotationId/:featureId`
  * new: `GET /annotation/:annotationId/markup/:featureId/superpixels`

This also adds new fields to the `GET /annotation/:annotationId` API: `responses` and `markup`; however, the `annotations` field is still returned (though it's deprecated) and contains the concatenation of both `responses` and `markup`.