### PR TITLE
Streamline dataset review store actions

### DIFF
--- a/web_external/vue/components/DatasetReview/DatasetReview.vue
+++ b/web_external/vue/components/DatasetReview/DatasetReview.vue
@@ -73,15 +73,13 @@ export default {
     created() {
     },
     mounted() {
-        this.getDataset({id: this.datasetId});
-        this.getReviewImages({id: this.datasetId});
+        this.loadDataset({id: this.datasetId});
     },
     methods: Object.assign({
     }, mapMutations([
         'toggleFlagged'
     ]), mapActions([
-        'getDataset',
-        'getReviewImages',
+        'loadDataset',
         'submitReview'
     ]))
 };

--- a/web_external/vue/components/DatasetReview/DatasetReviewStore.js
+++ b/web_external/vue/components/DatasetReview/DatasetReviewStore.js
@@ -51,13 +51,22 @@ export default {
         }
     },
     actions: {
-        getDataset({ commit }, { id }) {
+        loadDataset({ dispatch, commit }, { id }) {
+            // Reset state
+            commit('setDataset', null);
+            commit('setImages', []);
+            commit('setSubmissionState', SubmissionState.UNSUBMITTED);
+
+            // Fetch dataset
             DatasetService.get(id)
                 .done((resp) => {
                     commit('setDataset', resp);
                 });
+
+            // Fetch review images
+            dispatch('loadReviewImages', {id: id});
         },
-        getReviewImages({ state, commit }, { id }) {
+        loadReviewImages({ state, commit }, { id }) {
             DatasetService.getReviewImages(id)
                 .done((resp) => {
                     const images = resp.map((image) => {


### PR DESCRIPTION
Ensure that a call to the 'loadDataset' action is sufficient to update all the state related to the dataset, including the list of images.