### PR TITLE
Fix passing API parameters that can be parsed as numbers

### DIFF
--- a/server/api/base.py
+++ b/server/api/base.py
@@ -41,10 +41,15 @@ class IsicResource(Resource):
             if not isinstance(decodedParams, dict):
                 raise RestException('JSON content should be an object at the top level.')
         else:
+            # Return parameter unchanged
+            def passthrough(param):
+                return param
+
             decodedParams = {}
             for field, value in six.viewitems(params):
                 try:
-                    decodedValue = json.loads(value)
+                    # Decode parameter, parsing numbers as strings
+                    decodedValue = json.loads(value, parse_float=passthrough, parse_int=passthrough)
                 except ValueError:
                     # Assume this was just a simple string; invalid JSON should
                     # be caught later by type checking validation


### PR DESCRIPTION
Various errors occur when passing string parameters that can be parsed
as a float or int to the API.

One example is "POST /study" with "name" as "7":

    AttributeError: AttributeError("'int' object has no attribute 'strip'",)

Another example is "POST /dataset" with "description" as "100.0":

    AssertionError: AssertionError()

(The "assert isinstance(doc['description'], six.string_types)" check fails.)

This commit changes parameter decoding to always return simple values as
strings. Endpoint methods that require non-string parameters should
continue to explicitly convert the values after the parameters are
decoded.

Fixes #557 