### PR TITLE
Separate EXIF metadata

### DIFF
--- a/plugin_tests/image_metadata_test.py
+++ b/plugin_tests/image_metadata_test.py
@@ -119,7 +119,8 @@ class ImageMetadataTestCase(base.TestCase):
             'meta': {
                 'acquisition': {},
                 'clinical': {},
-                'unstructured': {}
+                'unstructured': {},
+                'unstructuredExif': {}
             },
             'privateMeta': {}
         }
@@ -1853,6 +1854,19 @@ class ImageMetadataTestCase(base.TestCase):
         errors, warnings = addImageMetadata(image, data)
         self.assertEqual([], errors)
         self.assertEqual(1, len(warnings))
+
+    def testAddImageMetadataExif(self):
+        data = {
+            'exif_1': 'value1',
+            'exif_2': 'value2',
+            'EXIF_3': 'value3'
+        }
+        image = self._createImage()
+        errors, _ = addImageMetadata(image, data)
+        self.assertEqual([], errors)
+        self.assertEqual('value1', image['meta']['unstructuredExif']['exif_1'])
+        self.assertEqual('value2', image['meta']['unstructuredExif']['exif_2'])
+        self.assertEqual('value3', image['meta']['unstructuredExif']['EXIF_3'])
 
     def testMelanocyticValidation(self):
         # Test populating melanocytic field based on diagnosis

--- a/server/models/dataset_helpers/image_metadata.py
+++ b/server/models/dataset_helpers/image_metadata.py
@@ -858,6 +858,20 @@ def _checkMetadataWarnings(clinical):
     return warnings
 
 
+def _extractExifMetadata(data, unstructuredExif):
+    """
+    Add EXIF-related metadata to its own unstructured field.
+
+    :param data: The image metadata.
+    :type data: dict
+    :param unstructuredExif: The dictionary of unstructured EXIF metadata.
+    :type unstructuredExif: dict
+    """
+    for key in list(six.iterkeys(data)):
+        if key.lower().startswith('exif_'):
+            unstructuredExif[key] = data.pop(key)
+
+
 def addImageMetadata(image, data):
     """
     Add acquisition and clinical metadata to an image. Data is expected to be a
@@ -936,6 +950,9 @@ def addImageMetadata(image, data):
 
     # Check metadata for warnings
     warnings.extend(_checkMetadataWarnings(clinical))
+
+    # Add EXIF-related metadata to its own unstructured field
+    _extractExifMetadata(data, image['meta']['unstructuredExif'])
 
     # Add remaining data as unstructured metadata
     image['meta']['unstructured'].update(data)

--- a/server/models/image.py
+++ b/server/models/image.py
@@ -73,6 +73,7 @@ class Image(Item):
             'acquisition': {},
             'clinical': {},
             'unstructured': {},
+            'unstructuredExif': {},
             'tags': [],
             'datasetId': dataset['_id'],
             'batchId': batch['_id']
@@ -316,7 +317,8 @@ class Image(Item):
             'meta': {
                 'acquisition': image['meta']['acquisition'],
                 'clinical': image['meta']['clinical'],
-                'unstructured': image['meta']['unstructured']
+                'unstructured': image['meta']['unstructured'],
+                'unstructuredExif': image['meta']['unstructuredExif']
             },
             'notes': {
                 'reviewed': image['meta'].get('reviewed', None),

--- a/web_external/ImagesGallery/Detail/imageDetailsPage.pug
+++ b/web_external/ImagesGallery/Detail/imageDetailsPage.pug
@@ -49,6 +49,14 @@
             td= key
             td= value
 
+      if !_.isEmpty(meta.unstructuredExif)
+        tr
+          td.isic-image-details-table-section-header(colspan=2) Unstructured EXIF Attributes
+        each value, key in meta.unstructuredExif
+          tr
+            td= key
+            td= value
+
       if _.has(meta, 'private')
         tr
           td.isic-image-details-table-section-header(colspan=2) Private Attributes


### PR DESCRIPTION
Move metadata fields that have the "exif_" prefix to a new dedicated unstructured field. This separates EXIF metadata from other unstructured metadata.

Fixes #463 