### PR TITLE
API to upload ZIP data directly to S3

### DIFF
--- a/plugin_tests/upload_test.py
+++ b/plugin_tests/upload_test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import base64
 import datetime
 import hashlib
 import json
@@ -210,7 +211,7 @@ class UploadTestCase(IsicTestCase):
         """Return Base64-encoded MD5 digest of the data."""
         md5 = hashlib.md5()
         md5.update(data)
-        return md5.digest().encode('base64')
+        return base64.b64encode(md5.digest())
 
     def testUploadDataset(self):
         File = self.model('file')

--- a/plugin_tests/upload_test.py
+++ b/plugin_tests/upload_test.py
@@ -155,8 +155,9 @@ class UploadTestCase(IsicTestCase):
 
         self.assertNoMail()
         resp = self.request(
-            path='/dataset/%s/zip' % dataset['_id'], method='POST', user=uploaderUser, params={
-                'zipFileId': str(zipFile['_id']),
+            path='/dataset/%s/imageZip' % dataset['_id'], method='POST', user=uploaderUser,
+            params={
+                'zipFileId': zipFile['_id'],
                 'signature': 'Test Uploader'
             })
         self.assertStatusOk(resp)

--- a/plugin_tests/upload_test.py
+++ b/plugin_tests/upload_test.py
@@ -98,14 +98,12 @@ class UploadTestCase(IsicTestCase):
 
         return uploaderUser
 
-    def _uploadDataset(self, uploaderUser, zipName, zipContentNames,
-                       datasetName, datasetDescription):
-        Dataset = self.model('dataset', 'isic_archive')
-        Folder = self.model('folder')
-        Upload = self.model('upload')
-
-        # Create a ZIP file of images
-        zipStream = BytesIO()
+    def _createZipFile(self, zipName, zipContentNames):
+        """
+        Create a zip file of images.
+        Returns (stream, size).
+        """
+        zipStream = six.BytesIO()
         zipGen = ZipGenerator(zipName)
         for fileName in zipContentNames:
             with open(os.path.join(self.testDataDir, fileName), 'rb') as \
@@ -117,6 +115,16 @@ class UploadTestCase(IsicTestCase):
         zipStream.seek(0, 2)
         zipSize = zipStream.tell()
         zipStream.seek(0)
+        return zipStream, zipSize
+
+    def _uploadDataset(self, uploaderUser, zipName, zipContentNames,
+                       datasetName, datasetDescription):
+        Dataset = self.model('dataset', 'isic_archive')
+        Folder = self.model('folder')
+        Upload = self.model('upload')
+
+        # Create a ZIP file of images
+        zipStream, zipSize = self._createZipFile(zipName, zipContentNames)
 
         # Create new folders in the uploader user's home
         resp = self.request(

--- a/server/api/dataset.py
+++ b/server/api/dataset.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import cherrypy
+import json
 import mimetypes
 
 from girder.api import access
@@ -25,13 +26,17 @@ from girder.api.rest import RestException, loadmodel
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType, SortDir
 from girder.exceptions import AccessException, ValidationException
+from girder.models.assetstore import Assetstore
 from girder.models.file import File
+from girder.models.setting import Setting
+from girder.models.upload import Upload
 from girder.utility import RequestBodyStream
 
 from .base import IsicResource
 from ..models.dataset import Dataset
 from ..models.image import Image
 from ..models.user import User
+from ..settings import PluginSettings
 
 CSV_FORMATS = [
     'text/csv',
@@ -58,6 +63,10 @@ class DatasetResource(IsicResource):
         self.route('POST', (), self.createDataset)
         self.route('POST', (':id', 'image'), self.addImage)
         self.route('POST', (':id', 'imageZip'), self.addImageZip)
+        self.route('POST', (':id', 'zip'), self.initZipUpload)
+        self.route('POST', (':id', 'zip', ':zipUploadId', 'part'), self.addZipUploadPart)
+        self.route('POST', (':id', 'zip', ':zipUploadId', 'completion'), self.finalizeZipUpload)
+        self.route('DELETE', (':id', 'zip', ':zipUploadId'), self.cancelZipUpload)
         self.route('GET', (':id', 'review'), self.getReviewImages)
         self.route('POST', (':id', 'review'), self.submitReviewImages)
         self.route('GET', (':id', 'metadata'), self.getRegisteredMetadata)
@@ -282,6 +291,267 @@ class DatasetResource(IsicResource):
         # TODO: make this return something
         Dataset().addZipBatch(
             dataset=dataset, zipFile=zipFile, signature=signature, user=user, sendMail=True)
+
+    @describeRoute(
+        Description('Start a new direct-to-S3 upload of a ZIP file of images.')
+        .notes('This endpoint returns information for the client to make a subsequent HTTP '
+               'request to S3 either to upload the file--if the file is less than 32 MB in '
+               'size--or to initiate a multi-part upload. For details on the S3 upload '
+               'workflow, see the AWS S3 documentation: '
+               'https://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html'
+               '\n\n'
+               'More specifically, this endpoint returns a JSON response in which the '
+               '`_id` field contains the ZIP file upload ID to use in subsequent requests '
+               'and in which the `s3` field contains the S3 request information. The client '
+               'should use the value of `s3.chunked` (boolean) to determine which upload '
+               'method to use.'
+               '\n\n'
+               '#### Single-part upload\n'
+               'When `s3.chunked` is false, the client should make an HTTP request with the '
+               'following properties to upload the file:\n\n'
+               '|             |                                                     |\n'
+               '|-------------|-----------------------------------------------------|\n'
+               '| **Method**  | `s3.request.method`                                 |\n'
+               '| **URL**     | `s3.request.url`                                    |\n'
+               '| **Headers** | One for each key-value pair in `s3.request.headers` |\n'
+               '|             | `Content-Length`: &lt;file size, in bytes&gt;       |\n'
+               '|             | `Content-MD5`: base64-encoded MD5 digest of data    |\n'
+               '| **Data**    | File content                                        |\n'
+               '|             |                                                     |\n'
+               '\n\n'
+               'This S3 request is documented at '
+               'https://docs.aws.amazon.com/AmazonS3/latest/dev/UploadObjSingleOpREST.html.'
+               '\n\n'
+               'To finalize the upload, the client should call '
+               '`POST /dataset/{id}/zip/{zipUploadId}/completion`.'
+               '\n\n'
+               '#### Multi-part upload\n'
+               'When `s3.chunked` is true, `s3.chunkLength` contains the size of each part '
+               'to be uploaded, and the client should make an HTTP request with the following '
+               'properties to initiate the multi-part upload:\n\n'
+               '|             |                                                     |\n'
+               '|-------------|-----------------------------------------------------|\n'
+               '| **Method**  | `s3.request.method`                                 |\n'
+               '| **URL**     | `s3.request.url`                                    |\n'
+               '| **Headers** | One for each key-value pair in `s3.request.headers` |\n'
+               '|             |                                                     |\n'
+               '\n\n'
+               'This request returns an XML document. The client should parse the XML to '
+               'get the multi-part upload ID. The XPath expression for the ID is '
+               '`/InitiateMultipartUploadResult/UploadId`.'
+               '\n\n'
+               'This S3 request is documented at '
+               'https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html.'
+               '\n\n'
+               'To continue the upload, the client should call '
+               '`POST /dataset/{id}/zip/{zipUploadId}/part`.')
+        .param('id', 'The ID of the dataset.', paramType='path')
+        .param('name', 'The name of the ZIP file.', paramType='form')
+        .param('size', 'The size of the ZIP file, in bytes.', paramType='form', dataType='integer')
+    )
+    @access.user
+    @loadmodel(model='dataset', plugin='isic_archive', level=AccessType.WRITE)
+    def initZipUpload(self, dataset, params):
+        params = self._decodeParams(params)
+        self.requireParams(['name', 'size'], params)
+
+        user = self.getCurrentUser()
+        User().requireCreateDataset(user)
+
+        # Require file name
+        name = params['name'].strip()
+        if not name:
+            raise ValidationException('File name must be specified.', 'name')
+
+        # Require integer size
+        try:
+            size = int(params['size'])
+        except ValueError:
+            raise RestException('Invalid file size.')
+
+        # Require positive size
+        if size <= 0:
+            raise ValidationException('File size must be greater than zero.', 'size')
+
+        # Create upload in the configured ZIP upload S3 assetstore
+        assetstore = Assetstore().findOne(
+            {'_id': Setting().get(PluginSettings.ZIP_UPLOAD_S3_ASSETSTORE_ID)})
+        if not assetstore:
+            raise RestException('ZIP upload S3 assetstore not configured.')
+
+        upload = Upload().createUpload(
+            user=user, name=name, parentType='dataset', parent=dataset, size=size,
+            mimeType='application/zip', assetstore=assetstore, attachParent=True)
+
+        return upload
+
+    @describeRoute(
+        Description('Upload a part of a ZIP file of images in a multi-part direct-to-S3 upload.')
+        .notes('After the client initiates a multi-part upload of a ZIP file of images, '
+               'this endpoint returns information for the client to make a subsequent HTTP '
+               'request to upload a part of the file directly to S3.'
+               '\n\n'
+               'More specifically, this endpoint returns a JSON response in which the `s3` field '
+               'contains the S3 request information. The client should make an HTTP request with '
+               'the following properties to update a part of the file:\n\n'
+               '|             |                                                     |\n'
+               '|-------------|-----------------------------------------------------|\n'
+               '| **Method**  | `s3.request.method`                                 |\n'
+               '| **URL**     | `s3.request.url`                                    |\n'
+               '| **Headers** | One for each key-value pair in `s3.request.headers` |\n'
+               '|             | `Content-Length`: &lt;part size, in bytes&gt;       |\n'
+               '|             | `Content-MD5`: base64-encoded MD5 digest of data    |\n'
+               '| **Data**    | Part content                                        |\n'
+               '|             |                                                     |\n'
+               '\n\n'
+               'This response to this request includes an `ETag` header. The client should parse '
+               'this header and store its value along with the associated part number. The '
+               'client will use these values later, when finalizing the upload.'
+               '\n\n'
+               'This S3 request is documented at '
+               'https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html.'
+               '\n\n'
+               'After uploading all the parts of the file, the client should call '
+               '`POST /dataset/{id}/zip/{zipUploadId}/completion` to finalize the upload.')
+        .param('id', 'The ID of the dataset.', paramType='path')
+        .param('zipUploadId', 'The ID of the ZIP file upload.', paramType='path')
+        .param('s3UploadId', 'S3 upload ID.', paramType='form')
+        .param('partNumber', 'Part number, starting at 1.', paramType='form', dataType='integer')
+        .param('contentLength', 'The size of the part, in bytes.', paramType='form',
+               dataType='integer')
+    )
+    @access.user
+    @loadmodel(map={'zipUploadId': 'upload'}, model='upload')
+    @loadmodel(model='dataset', plugin='isic_archive', level=AccessType.WRITE)
+    def addZipUploadPart(self, dataset, upload, params):
+        params = self._decodeParams(params)
+        self.requireParams(['s3UploadId', 'partNumber', 'contentLength'], params)
+
+        user = self.getCurrentUser()
+        User().requireCreateDataset(user)
+
+        if upload['userId'] != user['_id']:
+            raise AccessException('You did not initiate this upload.')
+
+        try:
+            partNumber = int(params['partNumber'])
+        except ValueError:
+            raise RestException('Invalid part number.')
+
+        try:
+            contentLength = int(params['contentLength'])
+        except ValueError:
+            raise RestException('Invalid content length.')
+
+        # For direct-to-S3 upload, S3AssetstoreAdapter expects its 'chunk' argument to be
+        # a string representation of the JSON object with keys: 's3UploadId', 'parentNumber',
+        # and 'contentLength'.
+        strParams = json.dumps({
+            's3UploadId': params['s3UploadId'],
+            'partNumber': partNumber,
+            'contentLength': contentLength
+        })
+        upload = Upload().handleChunk(upload, chunk=strParams, filter=False, user=user)
+
+        # Ensure 's3.request.headers' field exists
+        upload['s3']['request'].setdefault('headers', {})
+
+        return upload
+
+    @describeRoute(
+        Description('Finalize a direct-to-S3 upload of a ZIP file of images.')
+        .notes('The client should call this endpoint once all the parts of the ZIP file are '
+               'uploaded to S3.'
+               '\n\n'
+               'This endpoint returns a JSON response in which the `_id` field contains the '
+               'ZIP file ID to use in subsequent requests, such as '
+               '`POST /dataset/{id}/imageZip`.'
+               '\n\n'
+               '#### Single-part upload\n'
+               'For a single-part upload, no further requests are necessary.'
+               '\n\n'
+               '#### Multi-part upload\n'
+               '\n\n'
+               'For a multi-part upload, this endpoint additionally returns an '
+               '`s3` field that contains information to make an S3 request to complete the '
+               'upload by assembling the parts. The client should make an HTTP request with '
+               'the following properties to complete the upload:\n\n'
+               '|             |                                                            |\n'
+               '|-------------|------------------------------------------------------------|\n'
+               '| **Method**  | `s3.request.method`                                        |\n'
+               '| **URL**     | `s3.request.url`                                           |\n'
+               '| **Headers** | One for each key-value pair in `s3.request.headers`        |\n'
+               '|             | `Content-Length`: &lt;data size, in bytes&gt;              |\n'
+               '|             | `Content-MD5`: base64-encoded MD5 digest of data           |\n'
+               '| **Data**    | (See below)                                                |\n'
+               '|             |                                                            |\n'
+               '\n\n'
+               'The data for this request is an XML string with root element '
+               '`CompleteMultipartUpload`, and child `Part` elements, one for '
+               'each uploaded part. Each `Part` element has two children: '
+               '`PartNumber` and `ETag`. `PartNumber` elements should contain '
+               'an integer that indicates the position of the part in the file, '
+               'starting at 1. `ETag` elements should contain the ETag returned '
+               'after uploading the part to S3.'
+               '\n\n'
+               'This S3 request is documented at '
+               'https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html.')
+        .param('id', 'The ID of the dataset.', paramType='path')
+        .param('zipUploadId', 'The ID of the ZIP file upload.', paramType='path')
+    )
+    @access.user
+    @loadmodel(map={'zipUploadId': 'upload'}, model='upload')
+    @loadmodel(model='dataset', plugin='isic_archive', level=AccessType.WRITE)
+    def finalizeZipUpload(self, dataset, upload, params):
+        user = self.getCurrentUser()
+        User().requireCreateDataset(user)
+
+        if upload['userId'] != user['_id']:
+            raise AccessException('You did not initiate this upload.')
+
+        file = Upload().finalizeUpload(upload)
+
+        # For consistency with other upload endpoints, move S3 completion request information
+        # to the s3.request field. Delay adding the field until after the document is saved below.
+        s3Request = None
+        additionalKeys = file.get('additionalFinalizeKeys', [])
+        if 's3FinalizeRequest' in additionalKeys:
+            s3Request = file['s3FinalizeRequest']
+            del file['s3FinalizeRequest']
+            # Update additionalKeys, assuming it might be a list, tuple, or set
+            additionalKeys = list(additionalKeys)
+            index = additionalKeys.index('s3FinalizeRequest')
+            additionalKeys[index] = 's3'
+
+        # TODO: remove this once a bug in upstream Girder is fixed
+        file['attachedToType'] = ['dataset', 'isic_archive']
+        file = File().save(file)
+
+        if s3Request is not None:
+            file.setdefault('s3', {})['request'] = s3Request
+
+        return File().filter(file, user=user, additionalKeys=additionalKeys)
+
+    @describeRoute(
+        Description('Cancel a partially completed direct-to-S3 upload of a ZIP file of images.')
+        .notes('The client should call this endpoint to cancel a ZIP file upload before '
+               'finalizing it. This deletes the uploaded parts from S3 and removes the '
+               'ZIP file upload from the server.')
+        .param('id', 'The ID of the dataset.', paramType='path')
+        .param('zipUploadId', 'The ID of the ZIP file upload.', paramType='path')
+    )
+    @access.user
+    @loadmodel(map={'zipUploadId': 'upload'}, model='upload')
+    @loadmodel(model='dataset', plugin='isic_archive', level=AccessType.WRITE)
+    def cancelZipUpload(self, dataset, upload, params):
+        user = self.getCurrentUser()
+        User().requireCreateDataset(user)
+
+        if upload['userId'] != user['_id'] and not user['admin']:
+            raise AccessException('You did not initiate this upload.')
+
+        Upload().cancelUpload(upload)
+        return {'message': 'Upload canceled.'}
 
     @describeRoute(
         Description('Get a list of images in this dataset to QC Review.')

--- a/server/api/dataset.py
+++ b/server/api/dataset.py
@@ -57,7 +57,7 @@ class DatasetResource(IsicResource):
         self.route('PUT', (':id', 'access'), self.setDatasetAccess)
         self.route('POST', (), self.createDataset)
         self.route('POST', (':id', 'image'), self.addImage)
-        self.route('POST', (':id', 'zip'), self.addZipBatch)
+        self.route('POST', (':id', 'imageZip'), self.addImageZip)
         self.route('GET', (':id', 'review'), self.getReviewImages)
         self.route('POST', (':id', 'review'), self.submitReviewImages)
         self.route('GET', (':id', 'metadata'), self.getRegisteredMetadata)
@@ -252,14 +252,14 @@ class DatasetResource(IsicResource):
         return Image().filter(image, user=user)
 
     @describeRoute(
-        Description('Upload a batch of ZIP images to a dataset.')
+        Description('Add images from a ZIP file to a dataset.')
         .param('id', 'The ID of the dataset.', paramType='path')
         .param('zipFileId', 'The ID of the .zip file of images.', paramType='form')
         .param('signature', 'Signature of license agreement.', paramType='form')
     )
     @access.user
     @loadmodel(model='dataset', plugin='isic_archive', level=AccessType.WRITE)
-    def addZipBatch(self, dataset, params):
+    def addImageZip(self, dataset, params):
         params = self._decodeParams(params)
         self.requireParams(['zipFileId', 'signature'], params)
 

--- a/server/api/dataset.py
+++ b/server/api/dataset.py
@@ -511,25 +511,11 @@ class DatasetResource(IsicResource):
 
         file = Upload().finalizeUpload(upload)
 
-        # For consistency with other upload endpoints, move S3 completion request information
-        # to the s3.request field. Delay adding the field until after the document is saved below.
-        s3Request = None
-        additionalKeys = file.get('additionalFinalizeKeys', [])
-        if 's3FinalizeRequest' in additionalKeys:
-            s3Request = file['s3FinalizeRequest']
-            del file['s3FinalizeRequest']
-            # Update additionalKeys, assuming it might be a list, tuple, or set
-            additionalKeys = list(additionalKeys)
-            index = additionalKeys.index('s3FinalizeRequest')
-            additionalKeys[index] = 's3'
-
         # TODO: remove this once a bug in upstream Girder is fixed
         file['attachedToType'] = ['dataset', 'isic_archive']
         file = File().save(file)
 
-        if s3Request is not None:
-            file.setdefault('s3', {})['request'] = s3Request
-
+        additionalKeys = file.get('additionalFinalizeKeys', [])
         return File().filter(file, user=user, additionalKeys=additionalKeys)
 
     @describeRoute(

--- a/server/settings.py
+++ b/server/settings.py
@@ -17,13 +17,16 @@
 #  limitations under the License.
 ###############################################################################
 
+from girder.constants import AssetstoreType
 from girder.exceptions import ValidationException
+from girder.models.assetstore import Assetstore
 from girder.utility import setting_utilities
 
 
 class PluginSettings(object):
     DEMO_MODE = 'isic.demo_mode'
     MAX_ISIC_ID = 'isic.max_isic_id'
+    ZIP_UPLOAD_S3_ASSETSTORE_ID = 'isic.zip_upload_s3_assetstore_id'
 
 
 @setting_utilities.validator(PluginSettings.DEMO_MODE)
@@ -47,3 +50,22 @@ def _validateMaxIsicIdSetting(doc):
 @setting_utilities.default(PluginSettings.MAX_ISIC_ID)
 def _defaultMaxIsicIdSetting():
     return -1
+
+
+@setting_utilities.validator(PluginSettings.ZIP_UPLOAD_S3_ASSETSTORE_ID)
+def _validateZipUploadS3AssetstoreId(doc):
+    # Allow clearing setting
+    if not doc['value']:
+        return
+
+    # Require S3 assetstore
+    assetstore = Assetstore().load(doc['value'], exc=False)
+    if assetstore is None:
+        raise ValidationException('Invalid assetstore ID.', 'value')
+    if assetstore['type'] != AssetstoreType.S3:
+        raise ValidationException('ZIP upload assetstore must be an S3 assetstore.', 'value')
+
+
+@setting_utilities.default(PluginSettings.ZIP_UPLOAD_S3_ASSETSTORE_ID)
+def _defaultZipUploadS3AssetstoreId():
+    return None

--- a/web_client/templates/configView.pug
+++ b/web_client/templates/configView.pug
@@ -4,5 +4,9 @@ form#isic-config-form
     label.control-label(for="isic-config-demo-mode") Demo Mode
     p Newly registered users will automatically have full access to all phases.
     input#isic-config-demo-mode.input-sm.form-control(type="checkbox")
+  .form-group
+    label.control-label(for="isic-config-zip-upload-s3-assetstore-id") ZIP Upload S3 Assetstore ID
+    input#isic-config-zip-upload-s3-assetstore-id.input-sm.form-control(
+      type="text", placeholder="Enter S3 assetstore ID")
   p#isic-config-error-message.g-validation-failed-message
   input.btn.btn-sm.btn-primary(type="submit", value="Save")

--- a/web_client/views/ConfigView.js
+++ b/web_client/views/ConfigView.js
@@ -13,6 +13,9 @@ const ConfigView = View.extend({
             this._saveSettings([{
                 key: 'isic.demo_mode',
                 value: this.$('#isic-config-demo-mode').prop('checked')
+            }, {
+                key: 'isic.zip_upload_s3_assetstore_id',
+                value: this.$('#isic-config-zip-upload-s3-assetstore-id').val().trim()
             }]);
         }
     },
@@ -22,7 +25,8 @@ const ConfigView = View.extend({
             path: 'system/setting',
             data: {
                 list: JSON.stringify([
-                    'isic.demo_mode'
+                    'isic.demo_mode',
+                    'isic.zip_upload_s3_assetstore_id'
                 ])
             }
         }).done((resp) => {
@@ -31,6 +35,8 @@ const ConfigView = View.extend({
                 'checked',
                 resp['isic.demo_mode']
             );
+            this.$('#isic-config-zip-upload-s3-assetstore-id').val(
+                resp['isic.zip_upload_s3_assetstore_id']);
         });
     },
 

--- a/web_external/models/DatasetModel.js
+++ b/web_external/models/DatasetModel.js
@@ -21,7 +21,7 @@ const DatasetModel = AccessControlledModel.extend({
      */
     uploadBatch: function (zipFileId, signature) {
         return restRequest({
-            url: `${this.resourceName}/${this.id}/zip`,
+            url: `${this.resourceName}/${this.id}/imageZip`,
             method: 'POST',
             data: {
                 zipFileId: zipFileId,


### PR DESCRIPTION
Add endpoints to the dataset resource to support clients uploading ZIP files of images directly to S3. Once the file is uploaded, calling the existing `POST /dataset/{id}/imageZip` endpoint adds the images in the ZIP file to a dataset.

To start a new direct-to-S3 upload of a ZIP file of images, call `POST /dataset/{id}/zip`. Depending on the size of the ZIP file, one of two workflows is followed to upload the file to S3: single-part upload or multi-part upload.

In general, each HTTP request to these endpoints responds with information for the client to make a subsequent HTTP request to S3. The returned information includes the HTTP method, a pre-signed URL, and headers. The client is responsible to add headers such as Content-Length, Content-MD5, and additional data, as appropriate.

In the single-part upload workflow, the client uploads the file data to S3 in a single request. The client then notifies the server that the upload is complete by calling `POST /dataset/{id}/zip/{zipUploadId}/completion`.

In the multi-part upload workflow, the client uploads the file data to S3 in multiple requests. For each part of the file, the client calls `POST /dataset/{id}/zip/{part}` to get the S3 request information and then makes the S3 request, including the data for the part. Once all the parts have been uploaded, the client notifies the server that the upload is complete by calling `POST /dataset/{id}/zip/{zipUploadId}/completion`. The response to this request includes information to make an additional S3 request to finalize the upload.

See the documentation for each endpoint for details. Additionally, see the AWS S3 Uploading Objects documentation for supplemental information on the S3 API: https://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html

**NOTE**: Requires the following Girder changes:
- https://github.com/girder/girder/pull/2716
- https://github.com/girder/girder/pull/2740