### PR TITLE
Vagrant / ansible improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,10 +11,10 @@ Vagrant.configure("2") do |config|
   bind_node_modules = true?(ENV.fetch("BIND_NODE_MODULES", Vagrant::Util::Platform.windows?))
 
   config.vm.box = "bento/ubuntu-18.04"
-  config.vm.hostname = "isic-archive.localhost"
-  config.hostsupdater.aliases = ["isic-archive.test"]
+  config.vm.hostname = "isic-archive.test"
+  config.hostsupdater.aliases = ["proxy.isic-archive.test"]
   config.vm.provider "virtualbox" do |virtualbox|
-    virtualbox.name = "isic-archive.localhost"
+    virtualbox.name = "isic-archive.test"
     virtualbox.memory = 2048
     # Prevent 'xenial-16.04-cloudimg-console.log' from being created
     virtualbox.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
@@ -22,8 +22,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.network :private_network, ip: "172.16.0.10"
   config.vm.post_up_message = <<-eos
-ISIC Archive is running at http://isic-archive.localhost
-MailHog is running at http://isic-archive.localhost:8025
+ISIC Archive is running at http://isic-archive.test
+MailHog is running at http://isic-archive.test:8025
 eos
 
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,3 +1,4 @@
 vagrant-playbook.retry
 roles/DigitalSlideArchive.vips/
 roles/girder.girder/
+roles/large_image/

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,5 +4,5 @@
   version: master
 
 - src: https://github.com/girder/ansible-role-large-image.git
-  name: large-image
+  name: large_image
   version: master

--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -2,17 +2,16 @@
 
 - name: Install build dependencies
   apt:
-    name: "{{ item }}"
+    name:
+      - curl
+      - git
+      - libffi-dev
+      - build-essential
+      - libgif-dev
+      - libjpeg-dev
+      - libssl-dev
+      - zlib1g-dev
   become: yes
-  with_items:
-    - curl
-    - git
-    - libffi-dev
-    - build-essential
-    - libgif-dev
-    - libjpeg-dev
-    - libssl-dev
-    - zlib1g-dev
 
 - name: Download
   git:

--- a/ansible/roles/isic/meta/main.yml
+++ b/ansible/roles/isic/meta/main.yml
@@ -4,7 +4,7 @@ dependencies:
   - role: girder
   - role: supervisor
   - role: worker
-  - role: large-image
+  - role: large_image
     large_image_virtualenv: "{{ python_dist_path }}"
     large_image_tile_sources:
       - tiff

--- a/ansible/roles/isic/tasks/main.yml
+++ b/ansible/roles/isic/tasks/main.yml
@@ -12,10 +12,9 @@
 
 - name: Install package dependencies
   apt:
-    name: "{{ item }}"
+    name:
+      - p7zip-full
   become: yes
-  with_items:
-    - p7zip-full
 
 - name: Install large_image plugin
   command: "{{ python_dist_path }}/bin/girder-install plugin --force --symlink {{ large_image_path }}"

--- a/ansible/roles/isic/tasks/main.yml
+++ b/ansible/roles/isic/tasks/main.yml
@@ -54,8 +54,8 @@
 - name: Create Girder assetstore dir
   file:
     path: "{{ isic_archive_assetstore_path }}"
-    owner: ubuntu
-    group: ubuntu
+    owner: "{{ girder_user|default(ansible_user_id) }}"
+    group: "{{ girder_user|default(ansible_user_id) }}"
     state: directory
     recurse: yes
   become: yes

--- a/ansible/roles/nginx/templates/girder.conf.j2
+++ b/ansible/roles/nginx/templates/girder.conf.j2
@@ -41,7 +41,7 @@ server {
 {% if upstream_proxy %}
 server {
     listen 80;
-    server_name isic-archive.test;
+    server_name proxy.isic-archive.test;
 
     location / {
         proxy_pass http://localhost:{{ girder_port }};

--- a/ansible/roles/python/tasks/main.yml
+++ b/ansible/roles/python/tasks/main.yml
@@ -10,10 +10,9 @@
 
 - name: Upgrade pip
   pip:
-    name: "{{ item }}"
+    name:
+      - pip
+      # setuptools is needed to parse the new syntax in some requirements.txt
+      - setuptools
     state: latest
     virtualenv: "{{ python_dist_path }}"
-  with_items:
-    - pip
-    # setuptools is needed to parse the new syntax in some requirements.txt
-    - setuptools

--- a/ansible/roles/worker/tasks/main.yml
+++ b/ansible/roles/worker/tasks/main.yml
@@ -2,13 +2,12 @@
 
 - name: Install build dependencies
   apt:
-    name: "{{ item }}"
+    name:
+      - git
+      - libjpeg-dev
+      - zlib1g-dev
+      - libssl-dev
   become: yes
-  with_items:
-    - git
-    - libjpeg-dev
-    - zlib1g-dev
-    - libssl-dev
 
 - name: Download
   git:

--- a/ansible/vagrant-playbook.yml
+++ b/ansible/vagrant-playbook.yml
@@ -13,12 +13,12 @@
 
     - role: isic
       isic_archive_path: "{{ ansible_user_dir }}/isic_archive"
-      isic_email_host: "http://isic-archive.localhost"
+      isic_email_host: "http://isic-archive.test"
       isic_smtp_host: "localhost"
       isic_smtp_port: "1025"
 
     - role: nginx
-      site_hostname: isic-archive.localhost
+      site_hostname: isic-archive.test
       upstream_proxy: true
 
   post_tasks:

--- a/readme.rst
+++ b/readme.rst
@@ -39,7 +39,7 @@ Installation
     # from within the "isic-archive" sub-directory
     vagrant up
 
-* Use a web browser to visit ``http://isic-archive.localhost/`` from your host
+* Use a web browser to visit ``http://isic-archive.test/`` from your host
   development machine.
 
 * Login as the user ``admin`` with password ``password``. This user can be also used for granting
@@ -49,7 +49,7 @@ Installation
 Development
 ~~~~~~~~~~~
   **Note**:
-  You can visit ``http://isic-archive.test/`` on your host development
+  You can visit ``http://proxy.isic-archive.test/`` on your host development
   machine to access a version of the site that uses the local instance for all
   static front-end code, but proxies all API calls to the instance at
   ``isic-archive.com``.


### PR DESCRIPTION
* Don't hardcode Girder user in Ansible roles
* Use new list syntax for Ansible apt module
* Rename role "large_image"
* Rename development server to isic-archive.test, to work with Chrome