### PR TITLE
Treat PyMongo CommandCursor as a MongoProxy

### DIFF
--- a/server/models/image.py
+++ b/server/models/image.py
@@ -442,10 +442,10 @@ class Image(Item):
                     'default': None
                 }}
             ]
-        histogram = next(self.collection.aggregate([
+        histogram = next(iter(self.collection.aggregate([
             {'$match': query},
             {'$facet': facetStages}
-        ]))
+        ])))
 
         # Fix up the pipeline result
         if not histogram['__passedFilters__']:


### PR DESCRIPTION
This was broken by the changes in https://github.com/girder/girder/pull/2614