### PR TITLE
Fix randomly occurring race condition with localstack role

### DIFF
--- a/ansible/roles/localstack/tasks/main.yml
+++ b/ansible/roles/localstack/tasks/main.yml
@@ -21,6 +21,11 @@
     state: started
   become: true
 
+- name: Wait for localstack to be listening
+  wait_for:
+    port: 4572  # S3 port
+    timeout: 20
+
 - name: Create default bucket
   shell: |
     . {{ python_dist_path }}/bin/activate


### PR DESCRIPTION
The first time localstack is started it does a bootstrapping process that can take several seconds.