### PR TITLE
Revert "Expose Girder's static route for Swagger via Nginx"

### DIFF
--- a/ansible/roles/nginx/templates/girder.conf.j2
+++ b/ansible/roles/nginx/templates/girder.conf.j2
@@ -28,7 +28,7 @@ server {
         alias {{ isic_gui_dir }};
     }
     {% endif -%}
-    location ~ /(girder|api/v1|api/static|static|markup|uda) {
+    location ~ /(girder|api/v1|static|markup|uda) {
         proxy_pass http://localhost:{{ girder_port }};
 
         proxy_http_version 1.1;


### PR DESCRIPTION
This reverts commit 16c0ec299ad555a52cede67d0cd33e1e06c53731.

https://github.com/girder/girder/pull/2970 was the actual cause of this issue.