### PR TITLE
Remove unnecessary mongo flag for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: isic/isic_test:latest
       - image: circleci/mongo:3.6-ram
-        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
+        command: ["mongod", "--storageEngine", "ephemeralForTest"]
 
     working_directory: /home/circleci/project
 


### PR DESCRIPTION
CircleCI did some fixing of their mongo images and caused this flag to no longer be necessary.