### PR TITLE
Revert "Remove unnecessary mongo flag for CI"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: isic/isic_test:latest
       - image: circleci/mongo:3.6-ram
-        command: ["mongod", "--storageEngine", "ephemeralForTest"]
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     working_directory: /home/circleci/project
 


### PR DESCRIPTION
Reverts ImageMarkup/isic-archive#643.

The upstream breakage was fixed shortly after I merged this PR, see https://github.com/circleci/circleci-images/pull/388.