### PR TITLE
Add a test for submitting an annotation

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -26,4 +26,7 @@ RUN npm install --global yarn \
     p7zip-full \
   && pip3 install tox
 
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+    && apt-get install git-lfs
+
 USER circleci

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -22,6 +22,7 @@ RUN npm install --global yarn \
     tcl8.5-dev \
     tk8.5-dev \
     python-tk \
+    libvips-tools \
     # Install isic_archive dependencies
     p7zip-full \
   && pip3 install tox

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,0 +1,89 @@
+import io
+import json
+import os
+import re
+import urllib.parse
+
+import pytest
+import responses
+
+from girder.models.file import File
+from girder.models.item import Item
+from girder.utility import JsonEncoder
+
+from isic_archive.models.dataset import Dataset
+from isic_archive.models.image import Image
+from isic_archive.tasks import app
+from isic_archive.tasks.image import ingestImage
+
+
+@pytest.fixture(autouse=True)
+def celery_always_eager():
+    app.conf.task_always_eager = True
+
+
+@pytest.fixture
+def mocked_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
+
+@pytest.fixture
+def dataset(server, user):
+    d = Dataset().createDataset(
+        "test dataset", "test dataset", "CC-BY", "test", "test", user
+    )
+    yield d
+    Dataset().remove(d)
+
+
+@pytest.fixture
+def image_ingester(fsAssetstore, dataset, user, mocked_responses):
+    """Require a function for synchronously ingesting an image."""
+    def ingest_image(filename):
+        def file_download_callback(request):
+            file = File().load(request.path_url.split("/")[2], force=True)
+            stream = io.BytesIO()
+            for chunk in File().download(file, headers=False)():
+                stream.write(chunk)
+            stream.seek(0)
+            return 200, {}, stream.read()
+
+        def file_upload_callback(request):
+            params = urllib.parse.parse_qs(urllib.parse.urlparse(request.url).query)
+            item = Item().load(params["parentId"][0], force=True)
+            file = File().createFile(
+                user,
+                item,
+                params["name"][0],
+                int(params["size"][0]),
+                fsAssetstore,
+                mimeType=params["mimeType"][0] if "mimeType" in params else None,
+            )
+            return 200, {}, json.dumps(file, cls=JsonEncoder)
+
+        mocked_responses.add_callback(
+            mocked_responses.GET,
+            re.compile("%sfile/.*/download" % os.environ["ARCHIVE_API_URL"]),
+            callback=file_download_callback,
+        )
+        mocked_responses.add_callback(
+            mocked_responses.POST,
+            f"{os.environ['ARCHIVE_API_URL']}file",
+            callback=file_upload_callback,
+        )
+        with open(filename, "rb") as imageDataStream:
+            image = Dataset().addImage(
+                dataset=dataset,
+                imageDataStream=imageDataStream,
+                imageDataSize=os.path.getsize(filename),
+                filename=filename,
+                signature="signature",
+                user=user,
+            )
+
+        ingestImage(image["_id"])
+
+        return Image().load(image["_id"], force=True)
+
+    return ingest_image

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -1,0 +1,13 @@
+import pytest
+
+from isic_archive import IsicArchive
+
+from .fixtures import *  # noqa
+
+
+@pytest.mark.plugin("isic_archive", IsicArchive)
+def test_submit_annotation(dataset, image_ingester):
+    image = image_ingester("test/data/should-pass.jpg")
+    assert image["readable"]
+    assert image["ingested"]
+    assert image["ingestionState"] == {"largeImage": True, "superpixelMask": True}

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,10 @@ deps = numpy
        pytest
        pytest-girder>=3.0.0a6
        pytest-xdist
+       responses
 commands = pytest --boxed --verbose --showlocals --ignore test/e2e {posargs} test
+setenv =
+  ARCHIVE_API_URL = http://archive-test-url.com/
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
@brianhelba Ignore the first two commits of this PR, this is based on #630.

Note: the latest version of celery now supports running chord tasks in-process.