### PR TITLE
Do not allow redirects when making HTTP requests in tasks

### DIFF
--- a/isic_archive/tasks/zip.py
+++ b/isic_archive/tasks/zip.py
@@ -28,6 +28,7 @@ def _uploadZipfileToGirder(requestSession, filePath, dataset):
         'baseParentId': uploadCollection['_id']
     })
 
+    originalFileName = os.path.basename(filePath)
     fileSize = os.path.getsize(filePath)
     with open(filePath, 'rb') as fileStream:
         uploadFileResponse = requestSession.post(
@@ -35,7 +36,7 @@ def _uploadZipfileToGirder(requestSession, filePath, dataset):
             params={
                 'parentType': 'folder',
                 'parentId': uploadFolder['_id'],
-                'name': filePath,
+                'name': originalFileName,
                 'size': fileSize,
                 'mimeType': 'application/zip'
             },


### PR DESCRIPTION
This can mask misconfigurations, particularly when a 301 causes a POST to change to a GET.

Also, use only the base uploaded file name for temporary uploads