### PR TITLE
Ansible improvements

### DIFF
--- a/ansible/roles/isic/handlers/main.yml
+++ b/ansible/roles/isic/handlers/main.yml
@@ -24,13 +24,11 @@
   yarn:
     path: "{{ isic_repo_path }}/isic-archive-gui"
   listen:
-    - Build Girder web client
     - Build ISIC web client
   when: isic_web|bool
 
 - name: Build ISIC Admin GUI
   listen:
-    - Build Girder web client
     - Build ISIC web client
   command: yarn run build
   args:
@@ -39,7 +37,6 @@
 
 - name: Build ISIC Integration GUI
   listen:
-    - Build Girder web client
     - Build ISIC web client
   command: yarn run build:integration
   args:

--- a/ansible/roles/isic/meta/main.yml
+++ b/ansible/roles/isic/meta/main.yml
@@ -4,6 +4,7 @@ dependencies:
     vars:
       girder_daemonize: "{{ isic_server }}"
       girder_web: "{{ isic_web }}"
+      girder_version: "release"
 
   - role: large_image
     vars:

--- a/ansible/roles/isic/tasks/main.yml
+++ b/ansible/roles/isic/tasks/main.yml
@@ -27,7 +27,7 @@
     virtualenv: "{{ girder_virtualenv }}"
   notify:
     - Restart Girder
-    - Build Girder web client
+    - Build ISIC web client
 
 - name: Install ISIC dotenv configuration file
   template:


### PR DESCRIPTION
* Install only release versions of Girder via Ansible
* Don't trigger unnecessary rebuilds of the Girder web client when ISIC is updated
