### PR TITLE
Fix a bug with study creation

### DIFF
--- a/isic_archive/models/study.py
+++ b/isic_archive/models/study.py
@@ -50,7 +50,7 @@ class Study(Folder):
         self.validate({'meta': studyMeta})
 
         try:
-            study = self.createFolder(
+            study = Folder().createFolder(
                 parent=self.loadStudyCollection(),
                 name=name,
                 description='',


### PR DESCRIPTION
This ensures that Folder.validate, not Study.validate, will be called when the study folder is created.